### PR TITLE
Feature/list view fix

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_SERVER=http://testloadbalancer-1720165833.ap-northeast-2.elb.amazonaws.com
-REACT_APP_NAVER_MAP_KEY=0oaneja2l6
+REACT_APP_SERVER=
+REACT_APP_NAVER_MAP_KEY=

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_SERVER=
-REACT_APP_NAVER_MAP_KEY=
+REACT_APP_SERVER=http://testloadbalancer-1720165833.ap-northeast-2.elb.amazonaws.com
+REACT_APP_NAVER_MAP_KEY=0oaneja2l6

--- a/src/containers/ListViewContainer/ListViewContainer.tsx
+++ b/src/containers/ListViewContainer/ListViewContainer.tsx
@@ -161,7 +161,7 @@ const items = [
 
 ];
 
-const ListViewContainer = ({ data=items }: { data?: Array<any> }) => {
+const ListViewContainer = ({ data = items }: { data?: Array<any> }) => {
   // States
   const listView = useListView();
 
@@ -176,6 +176,8 @@ const ListViewContainer = ({ data=items }: { data?: Array<any> }) => {
   };
 
   const onItemClickHandler = (id: string | number) => {
+    // 여기 리덕스 코드 삽입. selected ZoneId 들어가도록
+
     listView.toggle(); // 어 이거 지우면 되는거 같은데
   };
 

--- a/src/containers/SearchInputStep1Container/Step1Container.tsx
+++ b/src/containers/SearchInputStep1Container/Step1Container.tsx
@@ -12,7 +12,6 @@ type InputProps = {
 
 const SearchInputStep1Container = ({ setIsHover }: InputProps) => {
 
-
   const onClickLocationHandler = () => {
     return setIsOpen(!isOpen)
   };

--- a/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
+++ b/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
@@ -181,8 +181,6 @@ const TimeCompareContainer = ({
   useEffect(() => {
     let timeCompareItems = getTimeCompareItems();
 
-    /** 지금 selectedZoneId 는 Dummy 입니다*/
-
     if (timeCompareItems === null) {
       setDefaultTimeCompareItem(currentZoneId, selectedZoneId)
         .then((results) => {

--- a/src/containers/TransportationContainer/TransportationContainer.tsx
+++ b/src/containers/TransportationContainer/TransportationContainer.tsx
@@ -198,6 +198,8 @@ const TransportationContainer = ({
     },
   });
 
+  console.log('transportation!', zoneId, startLocation);
+
   useEffect(() => {
     transit.loadTransitsByQueries({ zoneId, startLocation, mode: "LocationToZone" });
   }, []);
@@ -217,9 +219,9 @@ const TransportationContainer = ({
   });
 
   const tagButtonContents = [
-    { text: "#회사", step: "1" },
-    { text: "#버스", step: "2" },
-    { text: "#10-20m", step: "3" },
+    { text: "#회사"},
+    { text: "#버스"},
+    { text: "#10-20m"},
   ];
 
   // Item Components
@@ -236,7 +238,7 @@ const TransportationContainer = ({
   });
 
   const tagButtons = tagButtonContents.map((content) => {
-    return <a href={`/`}><TagButton fontSize="14px">{content.text}</TagButton></a>;
+    return <TagButton fontSize="14px">{content.text}</TagButton>;
   });
 
   // Handlers

--- a/src/containers/TransportationContainer/TransportationContainer.tsx
+++ b/src/containers/TransportationContainer/TransportationContainer.tsx
@@ -183,11 +183,8 @@ const TransportationArea = styled.div`
 `;
 
 const TransportationContainer = ({
-  zoneCode,
-  zoneAddress,
   zoneId,
   startLocation,
-  destinationLocation
 }: TransportationContainerProps) => {
   const transit = useTransit();
 
@@ -239,7 +236,7 @@ const TransportationContainer = ({
   });
 
   const tagButtons = tagButtonContents.map((content) => {
-    return <a href={`/searchInput/${content.step}`}><TagButton fontSize="14px">{content.text}</TagButton></a>;
+    return <a href={`/`}><TagButton fontSize="14px">{content.text}</TagButton></a>;
   });
 
   // Handlers

--- a/src/containers/ZoneSearchResultContainer/ZoneSearchResultContainer.tsx
+++ b/src/containers/ZoneSearchResultContainer/ZoneSearchResultContainer.tsx
@@ -15,6 +15,7 @@ interface ContainerProps {
   searchData?: SearchData;
 }
 
+
 const Container = Styled.div`
     width: 100%;
     height: 100%;

--- a/src/hooks/timeCompareHooks.ts
+++ b/src/hooks/timeCompareHooks.ts
@@ -1,0 +1,33 @@
+import { useSelector, useDispatch } from "react-redux";
+import { useCallback } from 'react';
+import { RootState } from '../modules'
+import { setUserLocation, setCompareLocation } from '../modules/timeCompare'
+
+const useTimeCompare = () => {
+  const { compareLocation, userLocation } = useSelector(
+    (state: RootState) => state.timeCompare
+  );
+  const dispatch = useDispatch();
+
+  const setLocation = useCallback(
+    (mode: "userLocation" | "compareLocation", location: {lat: number, lng: number}) => {
+      if (mode === 'userLocation') {
+        return dispatch(setUserLocation(location));
+      } else if (mode === "compareLocation") {
+        return dispatch(setCompareLocation(location));
+      } else {
+        console.log('유효한 작업이 아닙니다')
+        return;
+      }
+    },
+    [dispatch]
+  );
+
+  return {
+    compareLocation,
+    userLocation,
+    setLocation
+  };
+};
+
+export default useTimeCompare;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,6 +3,7 @@ import { all } from 'redux-saga/effects';
 
 // Reducers
 import listView from './listView'
+import timeCompare from './timeCompare';
 import room, { roomsSaga } from './room';
 import transit, { transitsSaga } from './transit';
 import place, { placesSaga } from './place';
@@ -14,6 +15,7 @@ import searchInput from './searchInput';
 const rootReducer = combineReducers({
   room,
   listView,
+  timeCompare,
   modal,
   place,
   transit,

--- a/src/modules/place/reducer.ts
+++ b/src/modules/place/reducer.ts
@@ -19,7 +19,7 @@ const place = createReducer<PlacesState, PlacesAction>(initialState, {
   [GET_PLACES_SUCCESS]: (state, action) => {
     const processed = { ...state };
     if (action.payload) {
-      processed.data = action.payload;
+      processed.data = action.payload ? action.payload : [];
     }
     return {
       ...processed,

--- a/src/modules/room/reducer.ts
+++ b/src/modules/room/reducer.ts
@@ -19,7 +19,7 @@ const room = createReducer<RoomsState, RoomsAction>(initialState, {
   [GET_ROOMS_SUCCESS]: (state, action) => {
     const processed = { ...state };
     if (action.payload) {
-      processed.data = action.payload;
+      processed.data = action.payload ? action.payload : [];
     }
     return {
       ...processed,

--- a/src/modules/timeCompare/actions.ts
+++ b/src/modules/timeCompare/actions.ts
@@ -1,0 +1,16 @@
+import { createAction } from "typesafe-actions";
+
+// 액션 타입
+export const SET_USER_LOCATION = "listView/SET_USER_LOCATION";
+export const SET_COMPARE_LOCATION = "listView/SET_COMPARE_LOCATION";
+
+// 액션 생성 함수
+export const setUserLocation = createAction(
+  SET_USER_LOCATION
+)<{lat: number, lng: number}>();
+export const setCompareLocation = createAction(
+  SET_COMPARE_LOCATION
+)<{lat: number, lng: number}>();
+
+
+

--- a/src/modules/timeCompare/index.ts
+++ b/src/modules/timeCompare/index.ts
@@ -1,0 +1,3 @@
+export { default } from './reducer';
+export * from './actions';
+export * from './types';

--- a/src/modules/timeCompare/reducer.ts
+++ b/src/modules/timeCompare/reducer.ts
@@ -1,0 +1,29 @@
+import { createReducer } from "typesafe-actions";
+import { TimeCompareState, TimeCompareAction } from "./types";
+import { SET_USER_LOCATION, SET_COMPARE_LOCATION } from "./actions";
+
+const initialState: TimeCompareState = {
+  compareLocation: {
+    lat: 0,
+    lng: 0,
+  },
+  userLocation: {
+    lat: 0,
+    lng: 0,
+  }
+};
+
+const listView = createReducer<TimeCompareState, TimeCompareAction>(initialState, {
+  [SET_USER_LOCATION]: (state, action) => {
+    const processed = { ...state };
+    processed.userLocation = action.payload;
+    return processed;
+  },
+  [SET_COMPARE_LOCATION]: (state, action) => {
+    const processed = { ...state };
+    processed.compareLocation = action.payload;
+    return processed;
+  },
+})
+
+export default listView;

--- a/src/modules/timeCompare/types.ts
+++ b/src/modules/timeCompare/types.ts
@@ -1,0 +1,15 @@
+import * as actions from './actions';
+import { ActionType } from "typesafe-actions";
+
+export type TimeCompareState = {
+  userLocation: {
+    lat: number;
+    lng: number;
+  },
+  compareLocation: {
+    lat: number;
+    lng: number;
+  }
+};
+
+export type TimeCompareAction = ActionType<typeof actions>;

--- a/src/modules/transit/reducer.ts
+++ b/src/modules/transit/reducer.ts
@@ -18,7 +18,7 @@ const transit = createReducer<TransitsState, TransitsAction>(initialState, {
   },
   [GET_TRANSITS_SUCCESS]: (state, action) => {
     const processed = { ...state };
-    processed.data = action.payload;
+    processed.data = action.payload ? action.payload : [];
     return {
       ...processed,
       error: null,

--- a/src/pages/LandingPage/LandingPage.scss
+++ b/src/pages/LandingPage/LandingPage.scss
@@ -354,7 +354,7 @@
         text-align: center;
         font-size: 36px;
         margin-top: 100px;
-        margin-bottom: 155px;
+        margin-bottom: 100px;
         .text-break {
           display: none;
         }

--- a/src/pages/SearchInputPage/SearchInputPage.tsx
+++ b/src/pages/SearchInputPage/SearchInputPage.tsx
@@ -99,8 +99,6 @@ const SearchInputPage = () => {
   };
 
   const stepForwardHandler = () => {
-    console.log("다음으로", step);
-    console.log('search data!', data);
     if (step < 3) {
       setStep(step + 1);
     } else {

--- a/src/pages/SearchInputPage/SearchInputPage.tsx
+++ b/src/pages/SearchInputPage/SearchInputPage.tsx
@@ -100,6 +100,7 @@ const SearchInputPage = () => {
 
   const stepForwardHandler = () => {
     console.log("다음으로", step);
+    console.log('search data!', data);
     if (step < 3) {
       setStep(step + 1);
     } else {

--- a/src/pages/ZoneDetailPage/ZoneDetailPage.scss
+++ b/src/pages/ZoneDetailPage/ZoneDetailPage.scss
@@ -1,3 +1,3 @@
 .zone-detail-page {
-  
+  margin-top: 50px;
 }

--- a/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
+++ b/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import "./ZoneDetailPage.scss";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import queryString from "query-string";
@@ -12,6 +12,11 @@ import PlaceContainer from "../../containers/PlaceContainer/PlaceContainer";
 
 import ZoneDetailHeaderInfo from "../../components/ZoneInfo/CurrentItemInfo";
 import TabItem from "../../components/TabItem/TabItem";
+
+type ZoneDetailPageProps = {
+  startLng: number;
+  startLat: number;
+}
 
 type paramsType = {
   id: string;
@@ -34,24 +39,20 @@ const StickyTabs = styled.div`
   }
 `;
 
-const ZoneDetailPage = ({ match }: RouteComponentProps<paramsType>) => {
+const ZoneDetailPage = ({ startLng, startLat, match }: ZoneDetailPageProps & RouteComponentProps<paramsType>) => {
+  const hashes = window.location.hash.split('/');
+  const [ zoneId, setZoneId ] = useState(Number(hashes[2]));
+
   let container = <div></div>;
   const tabItems = sections.map((section) => {
     return (
       <div key={section.name}>
-        <TabItem to={section.to} testId={section.to}>
+        <TabItem to={`${zoneId}/${section.to}`} testId={section.to}>
           {section.name}
         </TabItem>
       </div>
     );
   });
-
-  const queries = queryString.parse(window.location.search);
-  const zoneId = Number(queries.zoneId);
-  const startLat = Number(queries.startLat);
-  const startLng = Number(queries.startLng);
-  const destinationLat = Number(queries.destinationLat);
-  const destinationLng = Number(queries.destinationLng);
 
   switch (match.params.feature) {
     case "timecompare":
@@ -69,7 +70,6 @@ const ZoneDetailPage = ({ match }: RouteComponentProps<paramsType>) => {
           zoneCode="06020"
           zoneId={zoneId}
           startLocation={{ lat: startLat, lng: startLng }}
-          destinationLocation={{ lat: destinationLat, lng: destinationLng }}
         />
       );
       break;
@@ -82,7 +82,7 @@ const ZoneDetailPage = ({ match }: RouteComponentProps<paramsType>) => {
   }
 
   return (
-    <>
+    <div className="zone-detail-page">
       <ZoneDetailHeaderInfo
         className="header-info"
         address={address}
@@ -90,7 +90,7 @@ const ZoneDetailPage = ({ match }: RouteComponentProps<paramsType>) => {
       />
       <StickyTabs className="header-tabs">{tabItems}</StickyTabs>
       {container}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/ZoneSearchResultPage/ZoneSearchResultPage.tsx
+++ b/src/pages/ZoneSearchResultPage/ZoneSearchResultPage.tsx
@@ -13,10 +13,13 @@ import queryString from "query-string";
 import ZoneDetailPage from "../ZoneDetailPage/ZoneDetailPage";
 import ZoneSearchResultContainer from "../../containers/ZoneSearchResultContainer/ZoneSearchResultContainer";
 
-//Test
+// Test
 import { getTestZones } from "../../api/zoneAPI";
 import LoadingContainer from "../../containers/LoadingContainer/LoadingContainer";
 import ModalHooks from "../../components/Modal/ModalHooks";
+
+// Hooks
+import useTimeCompare from "../../hooks/timeCompareHooks";
 
 interface loadingContainer {
   data: locationData;
@@ -92,6 +95,8 @@ const ZoneSearchResultPage = () => {
   const params: any = queryString.parse(location.search);
   const searchData = convertSearchInfoData(params);
 
+  const timeCompare = useTimeCompare();
+
   const requestZones = useCallback(
     async (data: any) => {
       const headers = {
@@ -102,6 +107,13 @@ const ZoneSearchResultPage = () => {
 
       try {
         const res = await getTestZones({ headers, data });
+        
+        // 이용자가 설정한 주소 저장
+        timeCompare.setLocation("userLocation", {
+          lat: res.inputLocation.x,
+          lng: res.inputLocation.y
+        });
+
         setZoneData({
           inputLocation: res.inputLocation,
           data: res.data.map((value: any) => {
@@ -154,7 +166,7 @@ const ZoneSearchResultPage = () => {
             />
           )}
         </Route>
-        <Route exact path="/:id/:feature" component={ZoneDetailPage} />
+        <Route exact path="/:id/:feature" component={() => <ZoneDetailPage startLat={timeCompare.userLocation.lat} startLng={timeCompare.userLocation.lng} />} />
       </Switch>
     </HashRouter>
   );


### PR DESCRIPTION
[ zoneId 탭을 넘기면 사라지는 문제 해결 ]

- zoneId 가 Hash로 들어가고 이를 state로 받아오는 로직을 추가시켰습니다. 

[ 이용자가 설정한 주소를 저장하는 리덕스 로직 추가 ]

- timeCompare 라는 리덕스 모듈을 추가해서 이용자가 설정한 출발지 주소를 담게 하였으며 이용자가 시간 비교탭에서 추가로 설정할 본인의 집주소(혹은 다른 주소) 정보를 담을 수 있게 하였습니다.

[ 리덕스 리듀서 로직 수정 ]

타입스크립트로 서버에서 받아오는 데이터의 타입이 일정하다는 것을 완전히 보장할 수 없기 때문에 읽을 수 없는 값이 들어오면 빈 스토어에 빈 배열이 할당되도록 만들었습니다. <--- 스테이터스를 따로 검사하는 로직이 추가될 예정입니다.