### PR TITLE
Feature/timecompare feature added

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_SERVER=http://testloadbalancer-1720165833.ap-northeast-2.elb.amazonaws.com
-REACT_APP_NAVER_MAP_KEY=0oaneja2l6
+REACT_APP_SERVER=
+REACT_APP_NAVER_MAP_KEY=

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_SERVER=
-REACT_APP_NAVER_MAP_KEY=
+REACT_APP_SERVER=http://testloadbalancer-1720165833.ap-northeast-2.elb.amazonaws.com
+REACT_APP_NAVER_MAP_KEY=0oaneja2l6

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-REACT_APP_SERVER=http://testloadbalancer-1720165833.ap-northeast-2.elb.amazonaws.com
-REACT_APP_NAVER_MAP_KEY=0oaneja2l6
+REACT_APP_SERVER=
+REACT_APP_NAVER_MAP_KEY=

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-REACT_APP_SERVER=
-REACT_APP_NAVER_MAP_KEY=
+REACT_APP_SERVER=http://testloadbalancer-1720165833.ap-northeast-2.elb.amazonaws.com
+REACT_APP_NAVER_MAP_KEY=0oaneja2l6

--- a/src/api/coordinates.ts
+++ b/src/api/coordinates.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export type Coordinates = {
+  x: number;
+  y: number;
+};
+
+export type CoordinatesObj = {
+  code: number;
+  data: Coordinates;
+  message: string;
+};
+
+
+export async function getCoordinates (payload: string) {
+  const response = await axios.get<CoordinatesObj>(process.env.REACT_APP_SERVER + `/address/toLocation?address=${payload}`);
+  return response.data.data;
+}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -16,7 +16,10 @@ const Dialog = ({
   children,
   show,
 }: DialogProps) => {
-  const DialogWrapper = styled.div<{ show: boolean, backgroundColor: string | undefined; }>`
+  const DialogWrapper = styled.div<{
+    show: boolean;
+    backgroundColor: string | undefined;
+  }>`
     padding: 0;
     position: fixed;
     top: 0px;
@@ -29,11 +32,9 @@ const Dialog = ({
     background-color: var(--BackgroundColor);
 
     .postcode-iframe-wrapper {
-      
       width: 700px;
     }
   `;
-
 
   return (
     <DialogWrapper

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -17,13 +17,21 @@ const Dialog = ({
   display,
 }: DialogProps) => {
   const DialogWrapper = styled.div<{ display: boolean, backgroundColor: string | undefined; }>`
+    padding: 0;
     position: fixed;
-    // background-color: ${(props) => props.backgroundColor ? backgroundColor : 'rgba(0, 0, 0, 0.3'};
-    width: 100%;
+    top: 0px;
+    left: 0px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     height: 100%;
-    z-index: 1000;
-    padding: 30px;
-    display: ${(props) => (props.display ? 'block' : 'none')};
+    z-index: 9999999999;
+    background-color: var(--BackgroundColor);
+
+    .postcode-iframe-wrapper {
+      
+      width: 700px;
+    }
   `;
 
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -6,7 +6,7 @@ type DialogProps = {
   className: string;
   backgroundColor?: string;
   children?: React.ReactNode;
-  display: boolean;
+  show: boolean;
 };
 
 const Dialog = ({
@@ -14,9 +14,9 @@ const Dialog = ({
   className,
   backgroundColor,
   children,
-  display,
+  show,
 }: DialogProps) => {
-  const DialogWrapper = styled.div<{ display: boolean, backgroundColor: string | undefined; }>`
+  const DialogWrapper = styled.div<{ show: boolean, backgroundColor: string | undefined; }>`
     padding: 0;
     position: fixed;
     top: 0px;
@@ -38,7 +38,7 @@ const Dialog = ({
   return (
     <DialogWrapper
       backgroundColor={backgroundColor}
-      display={display}
+      show={show}
       onClick={click}
       className={className}
     >

--- a/src/components/ListViewItem/SearchResultItem.tsx
+++ b/src/components/ListViewItem/SearchResultItem.tsx
@@ -15,7 +15,7 @@ const METER_CONSTANT = 10;
 
 const ListViewItemWrapper = styled.div`
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   border-bottom: 1px solid rgba(182, 182, 182, 0.1);
   padding: 14px 20px;
 `;
@@ -29,6 +29,11 @@ const ZoneCodeWrapper = styled.div`
   line-height: 1.76;
   letter-spacing: -0.76px;
 `;
+
+const ZoneDetailInfo = styled.div`
+  display:flex;
+  justify-content: space-between;
+`
 
 const ZoneNameWrapper = styled.div`
   font-family: NotoSansRegular;
@@ -51,6 +56,7 @@ const DistanceWrapper = styled.div`
   line-height: 2;
   letter-spacing: -0.67px;
   text-align: right;
+  margin-left: 10px;
 `;
 
 const ListViewItem = ({
@@ -63,9 +69,12 @@ const ListViewItem = ({
 }: ListViewItemProps) => {
   return (
     <ListViewItemWrapper onClick={() => onClick(id)}>
-      <ZoneCodeWrapper>ZONE {zoneCode}</ZoneCodeWrapper>
-      <ZoneNameWrapper>{zoneName}</ZoneNameWrapper>
-      <DistanceWrapper>{(distance / METER_CONSTANT).toFixed(1)}km</DistanceWrapper>
+      <ZoneCodeWrapper>ZONE {zoneCode} </ZoneCodeWrapper>
+      <ZoneDetailInfo>
+        <ZoneNameWrapper>{zoneName}</ZoneNameWrapper>
+        <DistanceWrapper>{(distance / METER_CONSTANT).toFixed(1)}km</DistanceWrapper>
+      </ZoneDetailInfo>
+      
     </ListViewItemWrapper>
   );
 };

--- a/src/components/ListViewItem/TimeCompareListItem.tsx
+++ b/src/components/ListViewItem/TimeCompareListItem.tsx
@@ -6,13 +6,8 @@ import Icon, { IconType } from '../Icon/Icon';
 import { Button } from '../Button/Button';
 import { TimeCompareItem } from '../../utils/TimeCompare/functions';
 
-<<<<<<< HEAD
 import useTimeCompare from '../../hooks/timeCompareHooks';
 import { getCoordinates } from '../../api/coordinates';
-=======
-import useTimeCompare from "../../hooks/timeCompareHooks";
-import { getCoordinates } from "../../api/coordinates";
->>>>>>> 60a1d9d... 시간비교 기능 구현 완료
 
 // type
 export type TimeCompareListItemProps = {
@@ -163,18 +158,12 @@ const TimeCompareListItem = ({
   const timeCompareHook = useTimeCompare();
 
   const onAddressRegisterHandler = (content?: TimeCompareItem) => {
-<<<<<<< HEAD
-    if (editFunc && content) {
-      content.address = '주소 등록 완료';
-      editFunc(content, true);
-=======
     if (saveFunc && content && index) {
       content.heading = heading;
-      content.address = "주소 등록 완료";
+      content.address = '주소 등록 완료';
       saveFunc(content, index);
-      timeCompareHook.setSetterTargetFunc("compareItemAddress");
+      timeCompareHook.setSetterTargetFunc('compareItemAddress');
       timeCompareHook.setSetterModeFunc(true);
->>>>>>> 3fdadf3... 시간 비교 아이템 중간 저장 안되는 버그 수정
     }
   };
 

--- a/src/components/ListViewItem/TimeCompareListItem.tsx
+++ b/src/components/ListViewItem/TimeCompareListItem.tsx
@@ -1,12 +1,13 @@
-import React, { MouseEvent } from "react";
-import styled from "styled-components";
+import React, { MouseEvent } from 'react';
+import styled from 'styled-components';
 
 // Components
-import Icon, { IconType } from "../Icon/Icon";
-import { Button } from "../Button/Button";
-import { TimeCompareItem } from "../../utils/TimeCompare/functions";
+import Icon, { IconType } from '../Icon/Icon';
+import { Button } from '../Button/Button';
+import { TimeCompareItem } from '../../utils/TimeCompare/functions';
 
-import useTimeCompare from "../../hooks/timeCompareHooks";
+import useTimeCompare from '../../hooks/timeCompareHooks';
+import { getCoordinates } from '../../api/coordinates';
 
 // type
 export type TimeCompareListItemProps = {
@@ -121,8 +122,8 @@ const EditIconWrapper = styled.div<{ right?: string; top?: string }>`
   cursor: pointer;
   display: none;
   position: absolute;
-  top: ${({ top }) => (top ? top : "")};
-  right: ${({ right }) => (right ? right : "")};
+  top: ${({ top }) => (top ? top : '')};
+  right: ${({ right }) => (right ? right : '')};
   border-radius: 50%;
   background-color: white;
   padding: 3px;
@@ -153,18 +154,22 @@ const TimeCompareListItem = ({
   const timeCompareHook = useTimeCompare();
 
   const onAddressRegisterHandler = (content?: TimeCompareItem) => {
+    // 아 이 부분이 모달이 열리기도 전에 동작해버리는구나
     if (editFunc && content) {
-      content.address = timeCompareHook.compareItemAddress;
-      content.heading = heading;
-      content.location.lat = 37.5444;
-      content.location.lng = 127.0374;
+      content.address = '주소 등록 완료';
       editFunc(content, true);
     }
   };
 
-  const onCompleteHandler = (event: MouseEvent) => {
+  const onCompleteHandler = async (event: MouseEvent) => {
     if (editFunc && content) {
       content.heading = heading;
+      content.address = timeCompareHook.compareItemAddress;
+      const coordinates = await getCoordinates(
+        timeCompareHook.compareItemAddress
+      );
+      content.location.lat = coordinates.y;
+      content.location.lng = coordinates.x;
       editFunc(content);
     }
   };
@@ -195,7 +200,13 @@ const TimeCompareListItem = ({
   );
 
   return (
-    <TimeCompareListItemWrapper className={className}  href="#" onClick={(e) => { e.preventDefault() }}>
+    <TimeCompareListItemWrapper
+      className={className}
+      href="#"
+      onClick={(e) => {
+        e.preventDefault();
+      }}
+    >
       <ContentRow>
         <HeadingAndIcon>
           <Icon icon={icon} />
@@ -211,7 +222,7 @@ const TimeCompareListItem = ({
         </HeadingAndIcon>
         {!editMode && (
           <SavingTime>
-            {savingTime >= 0 ? savingTime + "분 절약" : savingTime + "분"}
+            {savingTime >= 0 ? savingTime + '분 절약' : savingTime + '분'}
           </SavingTime>
         )}
       </ContentRow>

--- a/src/components/ListViewItem/TimeCompareListItem.tsx
+++ b/src/components/ListViewItem/TimeCompareListItem.tsx
@@ -6,6 +6,8 @@ import Icon, { IconType } from "../Icon/Icon";
 import { Button } from "../Button/Button";
 import { TimeCompareItem } from "../../utils/TimeCompare/functions";
 
+import useTimeCompare from "../../hooks/timeCompareHooks";
+
 // type
 export type TimeCompareListItemProps = {
   icon: IconType;
@@ -146,16 +148,14 @@ const TimeCompareListItem = ({
     if (inputValue) {
       heading = inputValue;
     }
-    console.log(heading);
   };
 
+  const timeCompareHook = useTimeCompare();
+
   const onAddressRegisterHandler = (content?: TimeCompareItem) => {
-    // 주소, location 은 여기서 변경
-    // 현재는 테스트를 위해 수동으로 location과 주소를 할당합니다
     if (editFunc && content) {
-      address = "서울 성동구 뚝섬로 273";
+      content.address = timeCompareHook.compareItemAddress;
       content.heading = heading;
-      content.address = address;
       content.location.lat = 37.5444;
       content.location.lng = 127.0374;
       editFunc(content, true);

--- a/src/components/ListViewItem/TimeCompareListItem.tsx
+++ b/src/components/ListViewItem/TimeCompareListItem.tsx
@@ -6,8 +6,13 @@ import Icon, { IconType } from '../Icon/Icon';
 import { Button } from '../Button/Button';
 import { TimeCompareItem } from '../../utils/TimeCompare/functions';
 
+<<<<<<< HEAD
 import useTimeCompare from '../../hooks/timeCompareHooks';
 import { getCoordinates } from '../../api/coordinates';
+=======
+import useTimeCompare from "../../hooks/timeCompareHooks";
+import { getCoordinates } from "../../api/coordinates";
+>>>>>>> 60a1d9d... 시간비교 기능 구현 완료
 
 // type
 export type TimeCompareListItemProps = {

--- a/src/components/ListViewItem/TimeCompareListItem.tsx
+++ b/src/components/ListViewItem/TimeCompareListItem.tsx
@@ -25,7 +25,9 @@ export type TimeCompareListItemProps = {
   className?: string;
   editMode?: boolean;
   editModeFunc?: (item: TimeCompareItem) => void;
+  saveFunc?: (item: TimeCompareItem, index: number) => void;
   content?: TimeCompareItem;
+  index?: number;
   editFunc?: (item: TimeCompareItem, notCompleted?: boolean) => Promise<void>;
   deleteFunc?: (item: TimeCompareItem) => void;
 };
@@ -144,12 +146,14 @@ const TimeCompareListItem = ({
   className,
   content,
   editMode,
+  index,
   editFunc,
   deleteFunc,
   editModeFunc,
+  saveFunc,
 }: TimeCompareListItemProps) => {
   // Handlers
-  const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onInputHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = event.target.value;
     if (inputValue) {
       heading = inputValue;
@@ -159,9 +163,18 @@ const TimeCompareListItem = ({
   const timeCompareHook = useTimeCompare();
 
   const onAddressRegisterHandler = (content?: TimeCompareItem) => {
+<<<<<<< HEAD
     if (editFunc && content) {
       content.address = '주소 등록 완료';
       editFunc(content, true);
+=======
+    if (saveFunc && content && index) {
+      content.heading = heading;
+      content.address = "주소 등록 완료";
+      saveFunc(content, index);
+      timeCompareHook.setSetterTargetFunc("compareItemAddress");
+      timeCompareHook.setSetterModeFunc(true);
+>>>>>>> 3fdadf3... 시간 비교 아이템 중간 저장 안되는 버그 수정
     }
   };
 
@@ -217,7 +230,7 @@ const TimeCompareListItem = ({
           {editMode ? (
             <EditableHeading
               defaultValue={heading}
-              onChange={onChangeHandler}
+              onInput={onInputHandler}
               className="editable-heading"
             />
           ) : (

--- a/src/components/ListViewItem/TimeCompareListItem.tsx
+++ b/src/components/ListViewItem/TimeCompareListItem.tsx
@@ -154,7 +154,6 @@ const TimeCompareListItem = ({
   const timeCompareHook = useTimeCompare();
 
   const onAddressRegisterHandler = (content?: TimeCompareItem) => {
-    // 아 이 부분이 모달이 열리기도 전에 동작해버리는구나
     if (editFunc && content) {
       content.address = '주소 등록 완료';
       editFunc(content, true);

--- a/src/components/SearchInputItem/SearchInputStep1/ZoneSearchPopup.tsx
+++ b/src/components/SearchInputItem/SearchInputStep1/ZoneSearchPopup.tsx
@@ -32,7 +32,13 @@ const ZoneSearchPopUp = ({ close, setLocation }: ZoneSearchPopUpProps) => {
       }
       fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
     }
-    setLocationRedux(fullAddress)
+    setLocationRedux(fullAddress);
+
+    // 추가적으로 주소 정보를 활용하는 함수를 받아왔다면 실행
+    if (setLocation) {
+      setLocation(fullAddress);
+    }
+
     //@ts-ignore
     close();
   };

--- a/src/components/SearchInputItem/SearchInputStep1/ZoneSearchPopup.tsx
+++ b/src/components/SearchInputItem/SearchInputStep1/ZoneSearchPopup.tsx
@@ -38,10 +38,10 @@ const ZoneSearchPopUp = ({ close, setLocation }: ZoneSearchPopUpProps) => {
   };
 
   return (
-    <>
+    <div className="postcode-iframe-wrapper">
       <DaumPostcode onComplete={handleComplete} />
       <script src="http://dmaps.daum.net/map_js_init/postcode.v2.js?autoload=false"></script>
-    </>
+    </div>
   );
 };
 

--- a/src/components/TabItem/TabItem.tsx
+++ b/src/components/TabItem/TabItem.tsx
@@ -6,13 +6,16 @@ type TabItemProps = {
   children?: React.ReactNode;
   to: string;
   testId?: string;
+  active: boolean;
 };
 
-const TabItemWrapper = styled.div`
+const TabItemWrapper = styled.div<{ active: boolean }>`
   display: flex;
   justify-content: center;
   padding: 13.5px;
-  border-bottom: 2px solid var(--ItemColor);
+  transition: border-bottom 0.35s;
+  border-bottom: 2px solid
+    ${({ active }) => (active ? "var(--PrimaryColor)" : "var(--ItemColor)")};
   transition: border-bottom 0.35s;
   > a {
     text-decoration: none;
@@ -23,27 +26,28 @@ const TabItemWrapper = styled.div`
     line-height: 1.53;
     letter-spacing: -0.67px;
     text-align: center;
-    color: var(--DarkTextColor);
+    color: ${({ active }) =>
+      active ? "var(--LightTextColor)" : "var(--DarkTextColor)"};
     transition: color 0.35s;
 
     &:focus {
-      color: var(--LightTextColor);
       outline: none;
     }
   }
-  &:focus-within {
-    border-bottom: 2px solid var(--PrimaryColor);
-  }
 `;
 
-const TabItem = ({ children, to, testId }: TabItemProps) => {
+const TabItem = ({ children, to, testId, active }: TabItemProps) => {
   return (
-    <TabItemWrapper className="tabItem">
+    <TabItemWrapper className="tabItem" active={active}>
       <Link className="tabItemLink" to={`/${to}`} data-testid={testId}>
         {children}
       </Link>
     </TabItemWrapper>
   );
+};
+
+TabItem.defaultProps = {
+  active: false,
 };
 
 export default TabItem;

--- a/src/components/ZoneInfo/SearchResultInfo.tsx
+++ b/src/components/ZoneInfo/SearchResultInfo.tsx
@@ -45,6 +45,11 @@ const SearchResultInfoWrapper = styled.div<{ addedHeight: string }>`
   width: 100%;
   padding: 3.6vh 2.063rem 2.6vh;
 
+  .result-container {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
   @media only screen and (max-width: ${DEVICE_SIZE.mobile}) {
     padding: 0px 1.25rem 2vh;
   }
@@ -146,7 +151,7 @@ const SearchResultInfo = ({
 }: SearchResultInfoProps) => {
   return (
     <SearchResultInfoWrapper addedHeight={addedHeight} className={className}>
-      <ResultContainer>
+      <ResultContainer className="result-container">
         <LeftContent>
           <LeftRow>
             <EmphasisSpan bold>{itemCount}</EmphasisSpan>

--- a/src/components/ZoneInfo/SearchResultInfo.tsx
+++ b/src/components/ZoneInfo/SearchResultInfo.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import styled from "styled-components";
+import React from 'react';
+import styled from 'styled-components';
 
 // Icon
-import Icon from "../Icon/Icon";
+import Icon from '../Icon/Icon';
 
 type SearchResultInfoProps = {
   itemCount: string | number;
@@ -31,9 +31,9 @@ export type SearchData = {
 } | null;
 
 const DEVICE_SIZE = {
-  mobile: "425px",
-  tablet: "768px",
-  laptop: "1024px",
+  mobile: '425px',
+  tablet: '768px',
+  laptop: '1024px',
 };
 
 const SearchResultInfoWrapper = styled.div<{ addedHeight: string }>`
@@ -44,11 +44,6 @@ const SearchResultInfoWrapper = styled.div<{ addedHeight: string }>`
   max-width: 1120px;
   width: 100%;
   padding: 3.6vh 2.063rem 2.6vh;
-
-  .result-container {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
 
   @media only screen and (max-width: ${DEVICE_SIZE.mobile}) {
     padding: 0px 1.25rem 2vh;
@@ -90,20 +85,20 @@ const SearchContainer = styled.div`
   @media only screen and (max-width: ${DEVICE_SIZE.mobile}) {
     display: none;
   }
-  @media screen and (orientation:landscape) {
+  @media screen and (orientation: landscape) {
     display: none;
   }
 `;
 
 const Span = styled.span<SpanProps>`
-  color: ${(props) => (props.color ? props.color : "var(--GreyTextColor)")};
-  margin-right: ${(props) => (props.marginRight ? 0.625+`rem` : "")};
+  color: ${(props) => (props.color ? props.color : 'var(--GreyTextColor)')};
+  margin-right: ${(props) => (props.marginRight ? 0.625 + `rem` : '')};
 `;
 
 const EmphasisSpan = styled(Span)<EmphasisSpanProps>`
   color: var(--LightTextColor);
-  font-family: ${(props) => (props.bold ? "GothamMedium" : "NotoSansMedium")};
-  font-weight: ${(props) => (props.bold ? "500" : "300")};
+  font-family: ${(props) => (props.bold ? 'GothamMedium' : 'NotoSansMedium')};
+  font-weight: ${(props) => (props.bold ? '500' : '300')};
   font-size: ${(props) => (props.highlight ? 2 : 1.875)}rem;
   line-height: 2.375rem;
   letter-spacing: -${(props) => (props.highlight ? 0.089 : 0.084)}rem;
@@ -138,7 +133,7 @@ const Divider = styled.hr`
   @media only screen and (max-width: ${DEVICE_SIZE.mobile}) {
     display: none;
   }
-  @media screen and (orientation:landscape) {
+  @media screen and (orientation: landscape) {
     display: none;
   }
 `;
@@ -151,7 +146,7 @@ const SearchResultInfo = ({
 }: SearchResultInfoProps) => {
   return (
     <SearchResultInfoWrapper addedHeight={addedHeight} className={className}>
-      <ResultContainer className="result-container">
+      <ResultContainer>
         <LeftContent>
           <LeftRow>
             <EmphasisSpan bold>{itemCount}</EmphasisSpan>
@@ -166,7 +161,7 @@ const SearchResultInfo = ({
           </LeftRow>
         </LeftContent>
         <RightContent>
-          <Icon icon="share" size={"20px"} />
+          <Icon icon="share" size={'20px'} />
         </RightContent>
       </ResultContainer>
       {searchData && (
@@ -180,9 +175,7 @@ const SearchResultInfo = ({
             <SearchSpan color="var(--LightTextColor)" marginRight>
               까지 / {searchData.transitMode}
             </SearchSpan>
-            <SearchSpan marginRight>
-              {searchData.transferLimit}{" "}
-            </SearchSpan>
+            <SearchSpan marginRight>{searchData.transferLimit} </SearchSpan>
             <SearchSpan color="var(--LightTextColor)">
               로 / {searchData.minTime} - {searchData.maxTime}분
             </SearchSpan>

--- a/src/containers/ListViewContainer/ListViewContainer.tsx
+++ b/src/containers/ListViewContainer/ListViewContainer.tsx
@@ -91,17 +91,17 @@ const ListViewContainerWrapper = styled.div<{ clicked: boolean }>`
     forwards;
   overflow-y: scroll;
   &::-webkit-scrollbar {
-		width: 10px;
+    width: 10px;
     background: none;
-	}
-	&::-webkit-scrollbar-thumb {
-      background: none;
-      border-radius: 20px;
-	    opacity: .4;
-	}
-	&::-webkit-scrollbar-track {
-	    background: none;
-	}
+  }
+  &::-webkit-scrollbar-thumb {
+    background: none;
+    border-radius: 20px;
+    opacity: 0.4;
+  }
+  &::-webkit-scrollbar-track {
+    background: none;
+  }
 
   @media screen and (min-width: 1060px) {
     width: 332px;
@@ -158,7 +158,6 @@ const items = [
   { id: 11, zoneCode: 602011, zoneName: "강남구 역삼 1동", distance: 11.5 },
   { id: 12, zoneCode: 602011, zoneName: "강남구 역삼 1동", distance: 11.5 },
   { id: 13, zoneCode: 602011, zoneName: "강남구 역삼 1동", distance: 11.5 },
-
 ];
 
 const ListViewContainer = ({ data = items }: { data?: Array<any> }) => {
@@ -176,9 +175,7 @@ const ListViewContainer = ({ data = items }: { data?: Array<any> }) => {
   };
 
   const onItemClickHandler = (id: string | number) => {
-    // 여기 리덕스 코드 삽입. selected ZoneId 들어가도록
-
-    listView.toggle(); // 어 이거 지우면 되는거 같은데
+    listView.toggle();
   };
 
   // Props Handling

--- a/src/containers/ListViewContainer/ListViewContainer.tsx
+++ b/src/containers/ListViewContainer/ListViewContainer.tsx
@@ -17,13 +17,13 @@ const moveUp = keyframes`
   }
 
   75% {
-    transform: translateY(Calc(250px - 100vh));
+    transform: translateY(Calc(290px - 100vh));
     border-top-left-radius: 12px;
     border-top-right-radius: 12px;
   }
 
   100% {
-    transform: translateY(Calc(250px - 100vh));
+    transform: translateY(Calc(290px - 100vh));
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
   }
@@ -35,11 +35,11 @@ const moveUpDesktop = keyframes`
   }
 
   75% {
-    transform: translateY(Calc(270px - 100vh));
+    transform: translateY(Calc(380px - 100vh));
   }
 
   100% {
-    transform: translateY(Calc(270px - 100vh));
+    transform: translateY(Calc(380px - 100vh));
   }
 `;
 

--- a/src/containers/PlaceContainer/PlaceContainer.tsx
+++ b/src/containers/PlaceContainer/PlaceContainer.tsx
@@ -173,7 +173,7 @@ const PlaceContainer = ({ zoneId }: PlaceContainerProps) => {
 
   const placesTagButtons = place.data.map((item) => {
     return (
-      <div key={item.categoryName}>     
+      <div key={item.categoryName}>
         <TagButton
           fontSize="14px"
           onClick={() => selectPlaceContentHandler(item)}
@@ -185,7 +185,6 @@ const PlaceContainer = ({ zoneId }: PlaceContainerProps) => {
   });
 
   const placesListItems = selectedPlaceContent.placeVoList.map((item) => {
-    console.log(selectedPlaceContent.placeVoList);
     return (
       <div key={item.placeUrl}>
         <PlaceListItem

--- a/src/containers/PlaceContainer/PlaceContainer.tsx
+++ b/src/containers/PlaceContainer/PlaceContainer.tsx
@@ -164,7 +164,9 @@ const PlaceContainer = ({ zoneId }: PlaceContainerProps) => {
 
   // Handlers
   const selectPlaceContentHandler = (item: Place) => {
-    setSelectedPlaceContent(item);
+    const processed = { ...item };
+    processed.placeVoList = item.placeVoList;
+    setSelectedPlaceContent(processed);
   };
 
   // Dynamically Generated
@@ -185,7 +187,7 @@ const PlaceContainer = ({ zoneId }: PlaceContainerProps) => {
   const placesListItems = selectedPlaceContent.placeVoList.map((item) => {
     console.log(selectedPlaceContent.placeVoList);
     return (
-      <div key={item.address}>
+      <div key={item.placeUrl}>
         <PlaceListItem
           url={item.placeUrl}
           heading={item.placeName}

--- a/src/containers/SearchInputStep1Container/Step1Container.tsx
+++ b/src/containers/SearchInputStep1Container/Step1Container.tsx
@@ -43,7 +43,7 @@ const SearchInputStep1Container = ({ setIsHover }: InputProps) => {
         ?
         <Dialog
           className="pop_up"
-          display={isOpen}
+          show={isOpen}
           click={onClickLocationHandler}
         >
           <ZoneSearchPopUp

--- a/src/containers/TimeCompareContainer/TimeCompareContainer.test.tsx
+++ b/src/containers/TimeCompareContainer/TimeCompareContainer.test.tsx
@@ -20,10 +20,8 @@ describe("<TimeCompareContainer />", () => {
     const utils = render(
       <Provider store={store}>
       <Router history={history}>
-        <TimeCompareContainer currentZoneId={3771} startAddress={"강남구 1동"}  />
+        <TimeCompareContainer currentZoneId={3771} />
       </Router>
     </Provider>);
-
-    utils.getByText('강남구 1동');
   });
 });

--- a/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
+++ b/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
@@ -23,7 +23,7 @@ import {
 import useTimeCompare from "../../hooks/timeCompareHooks";
 
 // API
-import { getCoordinates } from "../../api/coordinates"
+import { getCoordinates } from "../../api/coordinates";
 
 // Data Types
 type TimeCompareContainerProps = {
@@ -170,9 +170,7 @@ const ItemAddButton = styled.a`
   }
 `;
 
-const TimeCompareContainer = ({
-  currentZoneId,
-}: TimeCompareContainerProps) => {
+const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
   const [timeCompareContents, setTimeCompareContents] = useState<
     TimeCompareItem[]
   >([]);
@@ -185,7 +183,10 @@ const TimeCompareContainer = ({
 
     if (timeCompareItems === null) {
       if (timeCompareHook.userAddress !== "주소를 설정해주세요") {
-        setDefaultTimeCompareItem(currentZoneId, timeCompareHook.compareLocation)
+        setDefaultTimeCompareItem(
+          currentZoneId,
+          timeCompareHook.compareLocation
+        )
           .then((results) => {
             setTimeCompareContents(results);
           })
@@ -269,7 +270,7 @@ const TimeCompareContainer = ({
     };
     processed.push(emptyItem);
     setTimeCompareContents(processed);
-    console.log('processed!', processed);
+    console.log("processed!", processed);
     setTimeCompareItems(processed);
   };
 
@@ -307,18 +308,20 @@ const TimeCompareContainer = ({
     );
   });
 
-
   const setUserLocationHandler = async (address: string) => {
     const coordinates = await getCoordinates(address);
     timeCompareHook.setAddress("userAddress", address);
-    timeCompareHook.setLocation("compareLocation", { lat: coordinates.y, lng: coordinates.x });
-  }
+    timeCompareHook.setLocation("compareLocation", {
+      lat: coordinates.y,
+      lng: coordinates.x,
+    });
+  };
 
   const setCompareItemLocationHandler = async (address: string) => {
     timeCompareHook.setAddress("compareItemAddress", address);
     timeCompareHook.setSetterTargetFunc("userAddress");
-  }
-  
+  };
+
   const onClickLocationHandler = () => {
     return timeCompareHook.setSetterModeFunc(!timeCompareHook.setterMode);
   };
@@ -332,13 +335,17 @@ const TimeCompareContainer = ({
           click={onClickLocationHandler}
         >
           <ZoneSearchPopUp
-            close={() => {onClickLocationHandler()}}
+            close={() => {
+              onClickLocationHandler();
+            }}
             //@ts-ignore
             setLocation={(address: string) => {
               if (timeCompareHook.setterTarget === "userAddress") {
                 setUserLocationHandler(address);
-              } else if (timeCompareHook.setterTarget === "compareItemAddress") {
-                setCompareItemLocationHandler(address); 
+              } else if (
+                timeCompareHook.setterTarget === "compareItemAddress"
+              ) {
+                setCompareItemLocationHandler(address);
               }
             }}
           />
@@ -356,18 +363,29 @@ const TimeCompareContainer = ({
             <Button onClick={onClickLocationHandler}>수정</Button>
           </StartPositionSelectWrapper>
           <TimeCompareList>
-            {timeCompareList.length !== 0 ? (
-              timeCompareList
-            ) : (
+            {timeCompareHook.userAddress === "주소를 설정해주세요" && (
               <p
                 style={{
-                  color: "white"
+                  color: "white",
                 }}
               >
                 주소가 설정되지 않았거나 추가할 아이템이 없습니다.
               </p>
             )}
-            <ItemAddButton style={{display: timeCompareHook.userAddress === "주소를 설정해주세요" ? "none" : "block"}} onClick={addTimeCompareItemHandler}>
+            {timeCompareHook.userAddress !== "주소를 설정해주세요" &&
+              timeCompareList.length === 0 && (
+                <LoadingDots color="white" size="15px" />
+              )}
+            {timeCompareList.length !== 0 && timeCompareList}
+            <ItemAddButton
+              style={{
+                display:
+                  timeCompareHook.userAddress === "주소를 설정해주세요"
+                    ? "none"
+                    : "block",
+              }}
+              onClick={addTimeCompareItemHandler}
+            >
               + 추가하기
             </ItemAddButton>
           </TimeCompareList>

--- a/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
+++ b/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect } from "react";
-import styled from "styled-components";
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
 
 // Components
-import { Button } from "../../components/Button/Button";
+import { Button } from '../../components/Button/Button';
 import TimeCompareListItem, {
   TimeCompareListItemProps,
-} from "../../components/ListViewItem/TimeCompareListItem";
-import LoadingDots from "../../components/Loading/LoadingDots";
-import ZoneSearchPopUp from "../../components/SearchInputItem/SearchInputStep1/ZoneSearchPopup";
-import Dialog from "../../components/Dialog/Dialog";
+} from '../../components/ListViewItem/TimeCompareListItem';
+import LoadingDots from '../../components/Loading/LoadingDots';
+import ZoneSearchPopUp from '../../components/SearchInputItem/SearchInputStep1/ZoneSearchPopup';
+import Dialog from '../../components/Dialog/Dialog';
 
 // Utils
 import {
@@ -17,13 +17,13 @@ import {
   getTimeCompareItems,
   TimeCompareItem,
   timeCompare,
-} from "../../utils/TimeCompare/functions";
+} from '../../utils/TimeCompare/functions';
 
 // Hooks
-import useTimeCompare from "../../hooks/timeCompareHooks";
+import useTimeCompare from '../../hooks/timeCompareHooks';
 
 // API
-import { getCoordinates } from "../../api/coordinates";
+import { getCoordinates } from '../../api/coordinates';
 
 // Data Types
 type TimeCompareContainerProps = {
@@ -182,7 +182,7 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
     let timeCompareItems = getTimeCompareItems();
 
     if (timeCompareItems === null) {
-      if (timeCompareHook.userAddress !== "주소를 설정해주세요") {
+      if (timeCompareHook.userAddress !== '주소를 설정해주세요') {
         setDefaultTimeCompareItem(
           currentZoneId,
           timeCompareHook.compareLocation
@@ -195,18 +195,18 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
           });
       }
     } else {
-      if (timeCompareHook.userAddress !== "주소를 설정해주세요") {
+      if (timeCompareHook.userAddress !== '주소를 설정해주세요') {
         setTimeCompareContents(timeCompareItems);
       }
     }
-  }, []);
+  }, [timeCompareHook.userAddress]);
 
   const updateTimeCompareItemHandler = async (
     item: TimeCompareItem,
     notCompleted?: boolean
   ) => {
     if (notCompleted) {
-      timeCompareHook.setSetterTargetFunc("compareItemAddress");
+      timeCompareHook.setSetterTargetFunc('compareItemAddress');
       timeCompareHook.setSetterModeFunc(true);
     }
     const processed = [...timeCompareContents];
@@ -219,7 +219,7 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
     }, 0);
     if (targetCount !== 1) {
       // 중복되는 주소와 제목을 가진 아이템이 있거나, 해당하는 주소와 제목의 아이템이 없음
-      alert("중복되는 이름과 주소의 아이템이 있습니다");
+      alert('중복되는 이름과 주소의 아이템이 있습니다');
     } else {
       const targetIndex = processed.findIndex(
         (x) => x.heading === item.heading && x.address === item.address
@@ -253,15 +253,15 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
 
   const addTimeCompareItemHandler = async () => {
     const processed = [...timeCompareContents];
-    const defaultName = "이름을 입력해주세요";
-    const defaultAddress = "주소를 입력해주세요";
+    const defaultName = '이름을 입력해주세요';
+    const defaultAddress = '주소를 입력해주세요';
     const emptyItem = {
-      icon: "company" as const,
+      icon: 'company' as const,
       heading: defaultName,
       savingTime: 0,
       address: defaultAddress,
-      distanceFrom: "0km",
-      distanceTo: "0km",
+      distanceFrom: '0km',
+      distanceTo: '0km',
       editMode: true,
       location: {
         lat: 0,
@@ -270,7 +270,7 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
     };
     processed.push(emptyItem);
     setTimeCompareContents(processed);
-    console.log("processed!", processed);
+    console.log('processed!', processed);
     setTimeCompareItems(processed);
   };
 
@@ -310,16 +310,16 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
 
   const setUserLocationHandler = async (address: string) => {
     const coordinates = await getCoordinates(address);
-    timeCompareHook.setAddress("userAddress", address);
-    timeCompareHook.setLocation("compareLocation", {
+    timeCompareHook.setAddress('userAddress', address);
+    timeCompareHook.setLocation('compareLocation', {
       lat: coordinates.y,
       lng: coordinates.x,
     });
   };
 
   const setCompareItemLocationHandler = async (address: string) => {
-    timeCompareHook.setAddress("compareItemAddress", address);
-    timeCompareHook.setSetterTargetFunc("userAddress");
+    timeCompareHook.setAddress('compareItemAddress', address);
+    timeCompareHook.setSetterTargetFunc('userAddress');
   };
 
   const onClickLocationHandler = () => {
@@ -340,10 +340,10 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
             }}
             //@ts-ignore
             setLocation={(address: string) => {
-              if (timeCompareHook.setterTarget === "userAddress") {
+              if (timeCompareHook.setterTarget === 'userAddress') {
                 setUserLocationHandler(address);
               } else if (
-                timeCompareHook.setterTarget === "compareItemAddress"
+                timeCompareHook.setterTarget === 'compareItemAddress'
               ) {
                 setCompareItemLocationHandler(address);
               }
@@ -363,16 +363,16 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
             <Button onClick={onClickLocationHandler}>수정</Button>
           </StartPositionSelectWrapper>
           <TimeCompareList>
-            {timeCompareHook.userAddress === "주소를 설정해주세요" && (
+            {timeCompareHook.userAddress === '주소를 설정해주세요' && (
               <p
                 style={{
-                  color: "white",
+                  color: 'white',
                 }}
               >
                 주소가 설정되지 않았거나 추가할 아이템이 없습니다.
               </p>
             )}
-            {timeCompareHook.userAddress !== "주소를 설정해주세요" &&
+            {timeCompareHook.userAddress !== '주소를 설정해주세요' &&
               timeCompareList.length === 0 && (
                 <LoadingDots color="white" size="15px" />
               )}
@@ -380,9 +380,9 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
             <ItemAddButton
               style={{
                 display:
-                  timeCompareHook.userAddress === "주소를 설정해주세요"
-                    ? "none"
-                    : "block",
+                  timeCompareHook.userAddress === '주소를 설정해주세요'
+                    ? 'none'
+                    : 'block',
               }}
               onClick={addTimeCompareItemHandler}
             >

--- a/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
+++ b/src/containers/TimeCompareContainer/TimeCompareContainer.tsx
@@ -285,11 +285,18 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
     setTimeCompareContents(processed);
   };
 
+  const saveChangeHandler = (item: TimeCompareItem, index: number) => {
+    const processed = [...timeCompareContents];
+    processed.splice(index, 1, item);
+    setTimeCompareContents(processed);
+    setTimeCompareItems(processed);
+  };
+
   // Dynamically Generated Elements
 
-  const timeCompareList = timeCompareContents.map((content) => {
+  const timeCompareList = timeCompareContents.map((content, index) => {
     return (
-      <div key={content.heading}>
+      <div key={index}>
         <TimeCompareListItem
           className="timecompare-item"
           icon={content.icon}
@@ -300,9 +307,11 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
           distanceTo={content.distanceTo}
           editMode={content.editMode}
           content={content}
+          index={index}
           editFunc={updateTimeCompareItemHandler}
           deleteFunc={deleteTimeCompareItemHandler}
           editModeFunc={editModeTriggerHandler}
+          saveFunc={saveChangeHandler}
         />
       </div>
     );
@@ -328,7 +337,7 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
 
   return (
     <>
-      {timeCompareHook.setterMode ? (
+      {timeCompareHook.setterMode && (
         <Dialog
           className="pop_up"
           show={timeCompareHook.setterMode}
@@ -350,47 +359,46 @@ const TimeCompareContainer = ({ currentZoneId }: TimeCompareContainerProps) => {
             }}
           />
         </Dialog>
-      ) : (
-        <TimeCompareContainerWrapper>
-          <TextSectionWrapper>
-            <BoldText>지금보다</BoldText>
-            <BoldText>얼마나 많은 시간이</BoldText>
-            <BoldText>절약될까요?</BoldText>
-          </TextSectionWrapper>
-
-          <StartPositionSelectWrapper>
-            <PlainText>{timeCompareHook.userAddress}</PlainText>
-            <Button onClick={onClickLocationHandler}>수정</Button>
-          </StartPositionSelectWrapper>
-          <TimeCompareList>
-            {timeCompareHook.userAddress === '주소를 설정해주세요' && (
-              <p
-                style={{
-                  color: 'white',
-                }}
-              >
-                주소가 설정되지 않았거나 추가할 아이템이 없습니다.
-              </p>
-            )}
-            {timeCompareHook.userAddress !== '주소를 설정해주세요' &&
-              timeCompareList.length === 0 && (
-                <LoadingDots color="white" size="15px" />
-              )}
-            {timeCompareList.length !== 0 && timeCompareList}
-            <ItemAddButton
-              style={{
-                display:
-                  timeCompareHook.userAddress === '주소를 설정해주세요'
-                    ? 'none'
-                    : 'block',
-              }}
-              onClick={addTimeCompareItemHandler}
-            >
-              + 추가하기
-            </ItemAddButton>
-          </TimeCompareList>
-        </TimeCompareContainerWrapper>
       )}
+      <TimeCompareContainerWrapper>
+        <TextSectionWrapper>
+          <BoldText>지금보다</BoldText>
+          <BoldText>얼마나 많은 시간이</BoldText>
+          <BoldText>절약될까요?</BoldText>
+        </TextSectionWrapper>
+
+        <StartPositionSelectWrapper>
+          <PlainText>{timeCompareHook.userAddress}</PlainText>
+          <Button onClick={onClickLocationHandler}>수정</Button>
+        </StartPositionSelectWrapper>
+        <TimeCompareList>
+          {timeCompareHook.userAddress === '주소를 설정해주세요' && (
+            <p
+              style={{
+                color: 'white',
+              }}
+            >
+              주소가 설정되지 않았거나 추가할 아이템이 없습니다.
+            </p>
+          )}
+          {timeCompareHook.userAddress !== '주소를 설정해주세요' &&
+            timeCompareList.length === 0 && (
+              <LoadingDots color="white" size="15px" />
+            )}
+          {timeCompareList.length !== 0 && timeCompareList}
+          <ItemAddButton
+            style={{
+              display:
+                timeCompareHook.userAddress === '주소를 설정해주세요'
+                  ? 'none'
+                  : 'block',
+            }}
+            onClick={addTimeCompareItemHandler}
+          >
+            + 추가하기
+          </ItemAddButton>
+        </TimeCompareList>
+      </TimeCompareContainerWrapper>
     </>
   );
 };

--- a/src/containers/TransportationContainer/TransportationContainer.tsx
+++ b/src/containers/TransportationContainer/TransportationContainer.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect } from "react";
-import styled from "styled-components";
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import useTransit from "../../hooks/transitHooks";
-import { Transit, TransitQuery } from "../../api/transits";
+import useTransit from '../../hooks/transitHooks';
+import { Transit, TransitQuery } from '../../api/transits';
 
 // Components
-import TransportationListItem from "../../components/ListViewItem/TransportationListItem";
-import { TagButton } from "../../components/Button/Button";
-import LoadingDots from "../../components/Loading/LoadingDots";
+import TransportationListItem from '../../components/ListViewItem/TransportationListItem';
+import { TagButton } from '../../components/Button/Button';
+import LoadingDots from '../../components/Loading/LoadingDots';
 
 type TransportationContainerProps = TransitQuery & {
   zoneCode: string | number;
@@ -67,7 +67,7 @@ const PathItem = styled.span`
   line-height: 1.88;
   letter-spacing: -0.71px;
   &:after {
-    content: "";
+    content: '';
     position: absolute;
     margin-left: 10px;
     margin-top: 10px;
@@ -92,7 +92,7 @@ const PathItemsWrapper = styled.div`
   }
 
   &:after {
-    content: "";
+    content: '';
     position: absolute;
     border-left: 0.1px solid var(--GreyTextColor);
     height: 40px;
@@ -190,10 +190,10 @@ const TransportationContainer = ({
 
   const [selectedTransit, setSelectTransit] = useState({
     transitObj: {
-      firstStation: "",
+      firstStation: '',
       firstStationLine: 0,
-      transitCount: "",
-      vehicleTypes: ["버스"],
+      transitCount: '',
+      vehicleTypes: ['버스'],
       time: 0,
     },
   });
@@ -201,14 +201,18 @@ const TransportationContainer = ({
   console.log('transportation!', zoneId, startLocation);
 
   useEffect(() => {
-    transit.loadTransitsByQueries({ zoneId, startLocation, mode: "LocationToZone" });
+    transit.loadTransitsByQueries({
+      zoneId,
+      startLocation,
+      mode: 'LocationToZone',
+    });
   }, []);
 
   const transportationContents = transit.data.map((data) => {
-    let transportationInfo = data.vehicleTypes[0] + " " + data.firstStationLine;
+    let transportationInfo = data.vehicleTypes[0] + ' ' + data.firstStationLine;
     if (data.vehicleTypes.length > 1) {
       for (let i = 1; i < data.vehicleTypes.length; i++) {
-        transportationInfo += " + " + data.vehicleTypes[i];
+        transportationInfo += ' + ' + data.vehicleTypes[i];
       }
     }
     return {
@@ -219,9 +223,9 @@ const TransportationContainer = ({
   });
 
   const tagButtonContents = [
-    { text: "#회사"},
-    { text: "#버스"},
-    { text: "#10-20m"},
+    { text: '#회사' },
+    { text: '#버스' },
+    { text: '#10-20m' },
   ];
 
   // Item Components
@@ -257,7 +261,7 @@ const TransportationContainer = ({
 
   return (
     <>
-      {transit.error && "에러가 발생했습니다"}
+      {transit.error && '에러가 발생했습니다'}
       <TransportationContainerWrapper>
         <PathArea>
           <Heading>
@@ -265,14 +269,14 @@ const TransportationContainer = ({
             출퇴근길을 위해서
           </Heading>
           <SubHeading>
-            선택했던 옵션을 바탕으로 <br /> 새로운 교통편을 안내해드릴게요.{" "}
+            선택했던 옵션을 바탕으로 <br /> 새로운 교통편을 안내해드릴게요.{' '}
           </SubHeading>
           <DesktopHeading>
             보다 만족스러운 <br />
             출퇴근길을 위해서
           </DesktopHeading>
           <DesktopSubHeading>
-            선택했던 옵션을 바탕으로 <br /> 새로운 교통편을 안내해드릴게요.{" "}
+            선택했던 옵션을 바탕으로 <br /> 새로운 교통편을 안내해드릴게요.{' '}
           </DesktopSubHeading>
           <TagButtonsWrapper>{tagButtons}</TagButtonsWrapper>
         </PathArea>
@@ -286,9 +290,9 @@ const TransportationContainer = ({
             ) : (
               <p
                 style={{
-                  textAlign: "center",
-                  color: "white",
-                  display: transit.loading ? "none" : "block",
+                  textAlign: 'center',
+                  color: 'white',
+                  display: transit.loading ? 'none' : 'block',
                 }}
               >
                 교통편이 없습니다

--- a/src/containers/ZoneSearchResultContainer/ZoneSearchResultContainer.tsx
+++ b/src/containers/ZoneSearchResultContainer/ZoneSearchResultContainer.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from "react";
+import React, { useCallback } from "react";
 import Styled from "styled-components";
 import Map, {
   RoomClickEvent,
@@ -9,12 +9,13 @@ import ListViewContainer from "../ListViewContainer/ListViewContainer";
 import ZoneSearchResultInfo, {
   SearchData,
 } from "../../components/ZoneInfo/SearchResultInfo";
+import { useDispatch } from "react-redux";
+import { toggleListView } from "../../modules/listView";
 
 interface ContainerProps {
   zonedata?: any;
   searchData?: SearchData;
 }
-
 
 const Container = Styled.div`
     width: 100%;
@@ -34,10 +35,20 @@ function ZoneSearchResultContainer(props: ContainerProps) {
   const { zonedata = {}, searchData } = props;
   const { inputLocation = {}, data = [] } = zonedata;
 
+  const dispatch = useDispatch();
+
   const RoomClickCallback = useCallback((props: RoomClickEvent) => {}, []);
-  const ClusterClickCallback = useCallback((props: ClusterClickEvent) => {}, []);
-  const ZoneClickCallback = useCallback((props: ZoneClickEvent) => {}, []);
-  
+
+  const ClusterClickCallback = useCallback((props: ClusterClickEvent) => {},
+  []);
+
+  const ZoneClickCallback = useCallback(
+    (props: ZoneClickEvent) => {
+      return dispatch(toggleListView());
+    },
+    [dispatch]
+  );
+
   return (
     <Container>
       <ZoneSearchResultInfo

--- a/src/hooks/timeCompareHooks.ts
+++ b/src/hooks/timeCompareHooks.ts
@@ -1,13 +1,17 @@
 import { useSelector, useDispatch } from "react-redux";
 import { useCallback } from 'react';
 import { RootState } from '../modules'
-import { setUserLocation, setCompareLocation } from '../modules/timeCompare'
+import { setUserLocation, setCompareLocation, setUserAddress } from '../modules/timeCompare'
 
 const useTimeCompare = () => {
-  const { compareLocation, userLocation } = useSelector(
+  const { compareLocation, userLocation, userAddress } = useSelector(
     (state: RootState) => state.timeCompare
   );
   const dispatch = useDispatch();
+
+  const setAddress = useCallback((address: string) => {
+    return dispatch(setUserAddress(address));
+  }, [dispatch])
 
   const setLocation = useCallback(
     (mode: "userLocation" | "compareLocation", location: {lat: number, lng: number}) => {
@@ -25,8 +29,10 @@ const useTimeCompare = () => {
 
   return {
     compareLocation,
+    userAddress,
     userLocation,
-    setLocation
+    setLocation,
+    setAddress
   };
 };
 

--- a/src/hooks/timeCompareHooks.ts
+++ b/src/hooks/timeCompareHooks.ts
@@ -1,38 +1,83 @@
 import { useSelector, useDispatch } from "react-redux";
-import { useCallback } from 'react';
-import { RootState } from '../modules'
-import { setUserLocation, setCompareLocation, setUserAddress } from '../modules/timeCompare'
+import { useCallback } from "react";
+import { RootState } from "../modules";
+import {
+  setUserLocation,
+  setCompareLocation,
+  setUserAddress,
+  setCompareItemAddress,
+  setSetterMode,
+  setSetterTarget,
+  setCompareItemContents  
+} from "../modules/timeCompare";
+
+import { TimeCompareItem } from "../utils/TimeCompare/functions";
 
 const useTimeCompare = () => {
-  const { compareLocation, userLocation, userAddress } = useSelector(
-    (state: RootState) => state.timeCompare
-  );
+  const {
+    compareLocation,
+    userLocation,
+    userAddress,
+    compareItemAddress,
+    setterMode,
+    setterTarget,
+    compareItemContents
+  } = useSelector((state: RootState) => state.timeCompare);
   const dispatch = useDispatch();
 
-  const setAddress = useCallback((address: string) => {
-    return dispatch(setUserAddress(address));
-  }, [dispatch])
+  const setAddress = useCallback(
+    (mode: "userAddress" | "compareItemAddress", address: string) => {
+      if (mode === "userAddress") {
+        return dispatch(setUserAddress(address));
+      } else if (mode === "compareItemAddress") {
+        return dispatch(setCompareItemAddress(address));
+      }
+    },
+    [dispatch]
+  );
 
   const setLocation = useCallback(
-    (mode: "userLocation" | "compareLocation", location: {lat: number, lng: number}) => {
-      if (mode === 'userLocation') {
+    (
+      mode: "userLocation" | "compareLocation",
+      location: { lat: number; lng: number }
+    ) => {
+      if (mode === "userLocation") {
         return dispatch(setUserLocation(location));
       } else if (mode === "compareLocation") {
         return dispatch(setCompareLocation(location));
       } else {
-        console.log('유효한 작업이 아닙니다')
+        console.log("유효한 작업이 아닙니다");
         return;
       }
     },
     [dispatch]
   );
 
+  const setSetterModeFunc = useCallback((payload: boolean) => {
+    return dispatch(setSetterMode(payload));
+  }, [dispatch]);
+
+  const setSetterTargetFunc = useCallback((payload: "userAddress" | "compareItemAddress") => {
+    return dispatch(setSetterTarget(payload));
+  }, [dispatch]);
+
+  const setCompareItemContentsFunc = useCallback((payload: TimeCompareItem[]) => {
+    return dispatch(setCompareItemContents(payload));
+  }, [dispatch]);
+
   return {
     compareLocation,
     userAddress,
     userLocation,
+    setterMode,
+    compareItemAddress,
+    setterTarget,
+    compareItemContents,
     setLocation,
-    setAddress
+    setAddress,
+    setSetterModeFunc,
+    setSetterTargetFunc,
+    setCompareItemContentsFunc
   };
 };
 

--- a/src/hooks/timeCompareHooks.ts
+++ b/src/hooks/timeCompareHooks.ts
@@ -1,6 +1,6 @@
-import { useSelector, useDispatch } from "react-redux";
-import { useCallback } from "react";
-import { RootState } from "../modules";
+import { useSelector, useDispatch } from 'react-redux';
+import { useCallback } from 'react';
+import { RootState } from '../modules';
 import {
   setUserLocation,
   setCompareLocation,
@@ -8,10 +8,10 @@ import {
   setCompareItemAddress,
   setSetterMode,
   setSetterTarget,
-  setCompareItemContents  
-} from "../modules/timeCompare";
+  setCompareItemContents,
+} from '../modules/timeCompare';
 
-import { TimeCompareItem } from "../utils/TimeCompare/functions";
+import { TimeCompareItem } from '../utils/TimeCompare/functions';
 
 const useTimeCompare = () => {
   const {
@@ -21,15 +21,15 @@ const useTimeCompare = () => {
     compareItemAddress,
     setterMode,
     setterTarget,
-    compareItemContents
+    compareItemContents,
   } = useSelector((state: RootState) => state.timeCompare);
   const dispatch = useDispatch();
 
   const setAddress = useCallback(
-    (mode: "userAddress" | "compareItemAddress", address: string) => {
-      if (mode === "userAddress") {
+    (mode: 'userAddress' | 'compareItemAddress', address: string) => {
+      if (mode === 'userAddress') {
         return dispatch(setUserAddress(address));
-      } else if (mode === "compareItemAddress") {
+      } else if (mode === 'compareItemAddress') {
         return dispatch(setCompareItemAddress(address));
       }
     },
@@ -38,32 +38,41 @@ const useTimeCompare = () => {
 
   const setLocation = useCallback(
     (
-      mode: "userLocation" | "compareLocation",
+      mode: 'userLocation' | 'compareLocation',
       location: { lat: number; lng: number }
     ) => {
-      if (mode === "userLocation") {
+      if (mode === 'userLocation') {
         return dispatch(setUserLocation(location));
-      } else if (mode === "compareLocation") {
+      } else if (mode === 'compareLocation') {
         return dispatch(setCompareLocation(location));
       } else {
-        console.log("유효한 작업이 아닙니다");
+        console.log('유효한 작업이 아닙니다');
         return;
       }
     },
     [dispatch]
   );
 
-  const setSetterModeFunc = useCallback((payload: boolean) => {
-    return dispatch(setSetterMode(payload));
-  }, [dispatch]);
+  const setSetterModeFunc = useCallback(
+    (payload: boolean) => {
+      return dispatch(setSetterMode(payload));
+    },
+    [dispatch]
+  );
 
-  const setSetterTargetFunc = useCallback((payload: "userAddress" | "compareItemAddress") => {
-    return dispatch(setSetterTarget(payload));
-  }, [dispatch]);
+  const setSetterTargetFunc = useCallback(
+    (payload: 'userAddress' | 'compareItemAddress') => {
+      return dispatch(setSetterTarget(payload));
+    },
+    [dispatch]
+  );
 
-  const setCompareItemContentsFunc = useCallback((payload: TimeCompareItem[]) => {
-    return dispatch(setCompareItemContents(payload));
-  }, [dispatch]);
+  const setCompareItemContentsFunc = useCallback(
+    (payload: TimeCompareItem[]) => {
+      return dispatch(setCompareItemContents(payload));
+    },
+    [dispatch]
+  );
 
   return {
     compareLocation,
@@ -77,7 +86,7 @@ const useTimeCompare = () => {
     setAddress,
     setSetterModeFunc,
     setSetterTargetFunc,
-    setCompareItemContentsFunc
+    setCompareItemContentsFunc,
   };
 };
 

--- a/src/modules/timeCompare/actions.ts
+++ b/src/modules/timeCompare/actions.ts
@@ -2,12 +2,17 @@ import { createAction } from "typesafe-actions";
 
 // 액션 타입
 export const SET_USER_LOCATION = "listView/SET_USER_LOCATION";
+export const SET_USER_ADDRESS = "listView/SET_USER_ADDRESS";
 export const SET_COMPARE_LOCATION = "listView/SET_COMPARE_LOCATION";
+
 
 // 액션 생성 함수
 export const setUserLocation = createAction(
   SET_USER_LOCATION
 )<{lat: number, lng: number}>();
+export const setUserAddress = createAction(
+  SET_USER_ADDRESS
+)<string>();
 export const setCompareLocation = createAction(
   SET_COMPARE_LOCATION
 )<{lat: number, lng: number}>();

--- a/src/modules/timeCompare/actions.ts
+++ b/src/modules/timeCompare/actions.ts
@@ -1,45 +1,37 @@
-import { createAction } from "typesafe-actions";
-import { TimeCompareItem } from "../../utils/TimeCompare/functions";
+import { createAction } from 'typesafe-actions';
+import { TimeCompareItem } from '../../utils/TimeCompare/functions';
 
 // 액션 타입
-export const SET_USER_LOCATION = "listView/SET_USER_LOCATION";
-export const SET_USER_ADDRESS = "listView/SET_USER_ADDRESS";
-export const SET_COMPARE_ITEM_ADDRESS = "listView/SET_COMPARE_ITEM_ADDRESS";
-export const SET_COMPARE_LOCATION = "listView/SET_COMPARE_LOCATION";
-export const SET_SETTER_MODE = "listView/SET_SETTER_MODE";
-export const SET_SETTER_TARGET = "listView/SET_SETTER_TARGET";
-export const SET_COMPARE_ITEMS = "listView/SET_COMPARE_ITEMS";
-
-
+export const SET_USER_LOCATION = 'listView/SET_USER_LOCATION';
+export const SET_USER_ADDRESS = 'listView/SET_USER_ADDRESS';
+export const SET_COMPARE_ITEM_ADDRESS = 'listView/SET_COMPARE_ITEM_ADDRESS';
+export const SET_COMPARE_LOCATION = 'listView/SET_COMPARE_LOCATION';
+export const SET_SETTER_MODE = 'listView/SET_SETTER_MODE';
+export const SET_SETTER_TARGET = 'listView/SET_SETTER_TARGET';
+export const SET_COMPARE_ITEMS = 'listView/SET_COMPARE_ITEMS';
 
 // 액션 생성 함수
-export const setUserLocation = createAction(
-  SET_USER_LOCATION
-)<{lat: number, lng: number}>();
+export const setUserLocation = createAction(SET_USER_LOCATION)<{
+  lat: number;
+  lng: number;
+}>();
+export const setCompareLocation = createAction(SET_COMPARE_LOCATION)<{
+  lat: number;
+  lng: number;
+}>();
 
-export const setCompareLocation = createAction(
-  SET_COMPARE_LOCATION
-)<{lat: number, lng: number}>();
+export const setUserAddress = createAction(SET_USER_ADDRESS)<string>();
 
-export const setUserAddress = createAction(
-  SET_USER_ADDRESS
-)<string>();
+export const setCompareItemAddress = createAction(SET_COMPARE_ITEM_ADDRESS)<
+  string
+>();
 
-export const setCompareItemAddress = createAction(
-  SET_COMPARE_ITEM_ADDRESS
-)<string>();
+export const setSetterMode = createAction(SET_SETTER_MODE)<boolean>();
 
-export const setSetterMode = createAction(
-  SET_SETTER_MODE
-)<boolean>();
+export const setSetterTarget = createAction(SET_SETTER_TARGET)<
+  'userAddress' | 'compareItemAddress'
+>();
 
-export const setSetterTarget = createAction(
-  SET_SETTER_TARGET
-)<"userAddress" | "compareItemAddress">();
-
-export const setCompareItemContents = createAction(
-  SET_COMPARE_ITEMS
-)<TimeCompareItem[]>();
-
-
-
+export const setCompareItemContents = createAction(SET_COMPARE_ITEMS)<
+  TimeCompareItem[]
+>();

--- a/src/modules/timeCompare/actions.ts
+++ b/src/modules/timeCompare/actions.ts
@@ -1,21 +1,45 @@
 import { createAction } from "typesafe-actions";
+import { TimeCompareItem } from "../../utils/TimeCompare/functions";
 
 // 액션 타입
 export const SET_USER_LOCATION = "listView/SET_USER_LOCATION";
 export const SET_USER_ADDRESS = "listView/SET_USER_ADDRESS";
+export const SET_COMPARE_ITEM_ADDRESS = "listView/SET_COMPARE_ITEM_ADDRESS";
 export const SET_COMPARE_LOCATION = "listView/SET_COMPARE_LOCATION";
+export const SET_SETTER_MODE = "listView/SET_SETTER_MODE";
+export const SET_SETTER_TARGET = "listView/SET_SETTER_TARGET";
+export const SET_COMPARE_ITEMS = "listView/SET_COMPARE_ITEMS";
+
 
 
 // 액션 생성 함수
 export const setUserLocation = createAction(
   SET_USER_LOCATION
 )<{lat: number, lng: number}>();
-export const setUserAddress = createAction(
-  SET_USER_ADDRESS
-)<string>();
+
 export const setCompareLocation = createAction(
   SET_COMPARE_LOCATION
 )<{lat: number, lng: number}>();
+
+export const setUserAddress = createAction(
+  SET_USER_ADDRESS
+)<string>();
+
+export const setCompareItemAddress = createAction(
+  SET_COMPARE_ITEM_ADDRESS
+)<string>();
+
+export const setSetterMode = createAction(
+  SET_SETTER_MODE
+)<boolean>();
+
+export const setSetterTarget = createAction(
+  SET_SETTER_TARGET
+)<"userAddress" | "compareItemAddress">();
+
+export const setCompareItemContents = createAction(
+  SET_COMPARE_ITEMS
+)<TimeCompareItem[]>();
 
 
 

--- a/src/modules/timeCompare/reducer.ts
+++ b/src/modules/timeCompare/reducer.ts
@@ -1,6 +1,14 @@
 import { createReducer } from "typesafe-actions";
 import { TimeCompareState, TimeCompareAction } from "./types";
-import { SET_USER_LOCATION, SET_COMPARE_LOCATION, SET_USER_ADDRESS } from "./actions";
+import {
+  SET_USER_LOCATION,
+  SET_COMPARE_LOCATION,
+  SET_USER_ADDRESS,
+  SET_COMPARE_ITEM_ADDRESS,
+  SET_SETTER_MODE,
+  SET_SETTER_TARGET,
+  SET_COMPARE_ITEMS
+} from "./actions";
 
 const initialState: TimeCompareState = {
   compareLocation: {
@@ -11,25 +19,52 @@ const initialState: TimeCompareState = {
     lat: 0,
     lng: 0,
   },
-  userAddress: "주소를 설정해주세요"
+  compareItemContents: [],
+  userAddress: "주소를 설정해주세요",
+  compareItemAddress: "",
+  setterMode: false,
+  setterTarget: "userAddress",
 };
 
-const listView = createReducer<TimeCompareState, TimeCompareAction>(initialState, {
-  [SET_USER_LOCATION]: (state, action) => {
-    const processed = { ...state };
-    processed.userLocation = action.payload;
-    return processed;
-  },
-  [SET_COMPARE_LOCATION]: (state, action) => {
-    const processed = { ...state };
-    processed.compareLocation = action.payload;
-    return processed;
-  },
-  [SET_USER_ADDRESS]: (state, action) => {
-    const processed = { ...state };
-    processed.userAddress = action.payload;
-    return processed;
+const listView = createReducer<TimeCompareState, TimeCompareAction>(
+  initialState,
+  {
+    [SET_USER_LOCATION]: (state, action) => {
+      const processed = { ...state };
+      processed.userLocation = action.payload;
+      return processed;
+    },
+    [SET_COMPARE_LOCATION]: (state, action) => {
+      const processed = { ...state };
+      processed.compareLocation = action.payload;
+      return processed;
+    },
+    [SET_COMPARE_ITEM_ADDRESS]: (state, action) => {
+      const processed = { ...state };
+      processed.compareItemAddress = action.payload;
+      return processed;
+    },
+    [SET_USER_ADDRESS]: (state, action) => {
+      const processed = { ...state };
+      processed.userAddress = action.payload;
+      return processed;
+    },
+    [SET_SETTER_MODE]: (state, action) => {
+      const processed = { ...state };
+      processed.setterMode = action.payload;
+      return processed;
+    },
+    [SET_SETTER_TARGET]: (state, action) => {
+      const processed = { ...state };
+      processed.setterTarget = action.payload;
+      return processed;
+    },
+    [SET_COMPARE_ITEMS]: (state, action) => {
+      const processed = { ...state };
+      processed.compareItemContents = action.payload;
+      return processed;
+    }
   }
-})
+);
 
 export default listView;

--- a/src/modules/timeCompare/reducer.ts
+++ b/src/modules/timeCompare/reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer } from "typesafe-actions";
 import { TimeCompareState, TimeCompareAction } from "./types";
-import { SET_USER_LOCATION, SET_COMPARE_LOCATION } from "./actions";
+import { SET_USER_LOCATION, SET_COMPARE_LOCATION, SET_USER_ADDRESS } from "./actions";
 
 const initialState: TimeCompareState = {
   compareLocation: {
@@ -10,7 +10,8 @@ const initialState: TimeCompareState = {
   userLocation: {
     lat: 0,
     lng: 0,
-  }
+  },
+  userAddress: "주소를 설정해주세요"
 };
 
 const listView = createReducer<TimeCompareState, TimeCompareAction>(initialState, {
@@ -24,6 +25,11 @@ const listView = createReducer<TimeCompareState, TimeCompareAction>(initialState
     processed.compareLocation = action.payload;
     return processed;
   },
+  [SET_USER_ADDRESS]: (state, action) => {
+    const processed = { ...state };
+    processed.userAddress = action.payload;
+    return processed;
+  }
 })
 
 export default listView;

--- a/src/modules/timeCompare/reducer.ts
+++ b/src/modules/timeCompare/reducer.ts
@@ -1,5 +1,5 @@
-import { createReducer } from "typesafe-actions";
-import { TimeCompareState, TimeCompareAction } from "./types";
+import { createReducer } from 'typesafe-actions';
+import { TimeCompareState, TimeCompareAction } from './types';
 import {
   SET_USER_LOCATION,
   SET_COMPARE_LOCATION,
@@ -7,8 +7,8 @@ import {
   SET_COMPARE_ITEM_ADDRESS,
   SET_SETTER_MODE,
   SET_SETTER_TARGET,
-  SET_COMPARE_ITEMS
-} from "./actions";
+  SET_COMPARE_ITEMS,
+} from './actions';
 
 const initialState: TimeCompareState = {
   compareLocation: {
@@ -20,10 +20,10 @@ const initialState: TimeCompareState = {
     lng: 0,
   },
   compareItemContents: [],
-  userAddress: "주소를 설정해주세요",
-  compareItemAddress: "",
+  userAddress: '주소를 설정해주세요',
+  compareItemAddress: '',
   setterMode: false,
-  setterTarget: "userAddress",
+  setterTarget: 'userAddress',
 };
 
 const listView = createReducer<TimeCompareState, TimeCompareAction>(
@@ -63,7 +63,7 @@ const listView = createReducer<TimeCompareState, TimeCompareAction>(
       const processed = { ...state };
       processed.compareItemContents = action.payload;
       return processed;
-    }
+    },
   }
 );
 

--- a/src/modules/timeCompare/types.ts
+++ b/src/modules/timeCompare/types.ts
@@ -1,20 +1,20 @@
 import * as actions from './actions';
-import { ActionType } from "typesafe-actions";
-import { TimeCompareItem } from "../../utils/TimeCompare/functions"
+import { ActionType } from 'typesafe-actions';
+import { TimeCompareItem } from '../../utils/TimeCompare/functions';
 
 export type TimeCompareState = {
   setterMode: boolean;
-  setterTarget: "userAddress" | "compareItemAddress"
+  setterTarget: 'userAddress' | 'compareItemAddress';
   userAddress: string;
   compareItemAddress: string;
   userLocation: {
     lat: number;
     lng: number;
-  },
+  };
   compareLocation: {
     lat: number;
     lng: number;
-  },
+  };
   compareItemContents: TimeCompareItem[];
 };
 

--- a/src/modules/timeCompare/types.ts
+++ b/src/modules/timeCompare/types.ts
@@ -2,6 +2,7 @@ import * as actions from './actions';
 import { ActionType } from "typesafe-actions";
 
 export type TimeCompareState = {
+  userAddress: string;
   userLocation: {
     lat: number;
     lng: number;
@@ -9,7 +10,7 @@ export type TimeCompareState = {
   compareLocation: {
     lat: number;
     lng: number;
-  }
+  },
 };
 
 export type TimeCompareAction = ActionType<typeof actions>;

--- a/src/modules/timeCompare/types.ts
+++ b/src/modules/timeCompare/types.ts
@@ -1,8 +1,12 @@
 import * as actions from './actions';
 import { ActionType } from "typesafe-actions";
+import { TimeCompareItem } from "../../utils/TimeCompare/functions"
 
 export type TimeCompareState = {
+  setterMode: boolean;
+  setterTarget: "userAddress" | "compareItemAddress"
   userAddress: string;
+  compareItemAddress: string;
   userLocation: {
     lat: number;
     lng: number;
@@ -11,6 +15,7 @@ export type TimeCompareState = {
     lat: number;
     lng: number;
   },
+  compareItemContents: TimeCompareItem[];
 };
 
 export type TimeCompareAction = ActionType<typeof actions>;

--- a/src/pages/SearchInputPage/SearchInputPage.scss
+++ b/src/pages/SearchInputPage/SearchInputPage.scss
@@ -15,7 +15,7 @@
   .search_elements_wrapper {
     display: flex;
     flex-direction: column;
-    margin-left: 20px;
+    padding: 20px;
     @media screen and (min-width: 1060px) {
       justify-content: center;
       align-items: center;
@@ -100,7 +100,6 @@
     width: fit-content;
     display: flex;
     flex-direction: column;
-    margin-left: 20px;
     border-radius: 8px;
     overflow: hidden;
     @media screen and (min-width: 1060px) {

--- a/src/pages/SearchInputPage/SearchInputPage.tsx
+++ b/src/pages/SearchInputPage/SearchInputPage.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from "react";
-import "./SearchInputPage.scss";
-import styled from "styled-components";
-import { useHistory } from "react-router-dom";
+import React, { useState } from 'react';
+import './SearchInputPage.scss';
+import styled from 'styled-components';
+import { useHistory } from 'react-router-dom';
 
-import SearchInputStep1Container from "../../containers/SearchInputStep1Container/Step1Container";
-import SearchInputStep2Container from "../../containers/SearchInputStep2Container/Step2Container";
-import SearchInputStep3Container from "../../containers/SearchInputStep3Container/Step3Container";
-import useSearchInput from "../../hooks/useSearchInput";
+import SearchInputStep1Container from '../../containers/SearchInputStep1Container/Step1Container';
+import SearchInputStep2Container from '../../containers/SearchInputStep2Container/Step2Container';
+import SearchInputStep3Container from '../../containers/SearchInputStep3Container/Step3Container';
+import useSearchInput from '../../hooks/useSearchInput';
 
 const MoreItemButton = styled.div`
   width: 100%;
@@ -103,7 +103,7 @@ const SearchInputPage = () => {
       // if (step === 1) {
       //   history.replace("/search", { step: step + 1 });
       // } else {
-      history.push("/search", { step: step + 1 })
+      history.push('/search', { step: step + 1 });
     } else {
       history.push(
         `/search?address=${data.address}&addressTag=${data.addressTag}&maxTime=${data.maxTime}&minTime=${data.minTime}&transferLimit=${data.transferLimit}&transitMode=${data.transitMode}`
@@ -127,18 +127,18 @@ const SearchInputPage = () => {
       break;
   }
 
-  const prev = "< 이전으로";
-  const next = "다음으로 >";
+  const prev = '< 이전으로';
+  const next = '다음으로 >';
 
   const shake = () => {
-    const option = document.querySelector("div#option");
+    const option = document.querySelector('div#option');
     if (option) {
-      option.classList.add("apply-shake");
+      option.classList.add('apply-shake');
     }
     setTimeout(function () {
-      const option = document.querySelector("div#option");
+      const option = document.querySelector('div#option');
       if (option) {
-        option.classList.remove("apply-shake");
+        option.classList.remove('apply-shake');
       }
     }, 600);
   };
@@ -154,31 +154,31 @@ const SearchInputPage = () => {
               {step === 1 ? (
                 <></>
               ) : (
-                  <MoreItemButton onClick={() => stepPrevHandler()}>
-                    {prev}
-                  </MoreItemButton>
-                )}
+                <MoreItemButton onClick={() => stepPrevHandler()}>
+                  {prev}
+                </MoreItemButton>
+              )}
               <MoreItemButtonHovered onClick={() => stepForwardHandler()}>
                 {next}
               </MoreItemButtonHovered>
             </ButtonWrapper>
           ) : (
-              <ButtonWrapper>
-                <div className="optionWrapper">
-                  <div id="option" className="option">
-                    * 옵션을 선택해주세요
+            <ButtonWrapper>
+              <div className="optionWrapper">
+                <div id="option" className="option">
+                  * 옵션을 선택해주세요
                 </div>
-                </div>
-                {step === 1 ? (
-                  <></>
-                ) : (
-                    <MoreItemButton onClick={() => stepPrevHandler()}>
-                      {prev}
-                    </MoreItemButton>
-                  )}
-                <MoreItemButton onClick={() => shake()}>{next}</MoreItemButton>
-              </ButtonWrapper>
-            )}
+              </div>
+              {step === 1 ? (
+                <></>
+              ) : (
+                <MoreItemButton onClick={() => stepPrevHandler()}>
+                  {prev}
+                </MoreItemButton>
+              )}
+              <MoreItemButton onClick={() => shake()}>{next}</MoreItemButton>
+            </ButtonWrapper>
+          )}
         </SearchInputWrapper>
       </div>
     </>

--- a/src/pages/ZoneDetailPage/ZoneDetailPage.scss
+++ b/src/pages/ZoneDetailPage/ZoneDetailPage.scss
@@ -5,7 +5,6 @@
     width: 1120px;
     margin: auto;
     margin-top: 100px;
-    
   }
 
   .header-info {
@@ -32,7 +31,7 @@
         }
       }
       &::before {
-        content: "";
+        content: '';
         position: absolute;
         bottom: 0px;
         width: 100%;

--- a/src/pages/ZoneDetailPage/ZoneDetailPage.scss
+++ b/src/pages/ZoneDetailPage/ZoneDetailPage.scss
@@ -1,3 +1,44 @@
 .zone-detail-page {
   margin-top: 50px;
+
+  @media screen and (min-width: 1060px) {
+    width: 1120px;
+    margin: auto;
+    margin-top: 100px;
+    
+  }
+
+  .header-info {
+    @media screen and (min-width: 1060px) {
+      align-items: flex-start;
+      > h1:first-child {
+        order: 2;
+        font-size: 20px;
+      }
+      margin-bottom: 80px;
+      padding-left: 30px;
+    }
+  }
+
+  .header-tabs {
+    @media screen and (min-width: 1060px) {
+      align-items: flex-start;
+      padding-left: 20px;
+      position: relative;
+      > * {
+        flex: initial;
+        a {
+          font-size: 20px;
+        }
+      }
+      &::before {
+        content: "";
+        position: absolute;
+        bottom: 0px;
+        width: 100%;
+        z-index: -1;
+        border-bottom: 2px solid var(--ItemColor);
+      }
+    }
+  }
 }

--- a/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
+++ b/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
@@ -16,7 +16,7 @@ import TabItem from "../../components/TabItem/TabItem";
 type ZoneDetailPageProps = {
   startLng: number;
   startLat: number;
-}
+};
 
 type paramsType = {
   id: string;
@@ -39,15 +39,24 @@ const StickyTabs = styled.div`
   }
 `;
 
-const ZoneDetailPage = ({ startLng, startLat, match }: ZoneDetailPageProps & RouteComponentProps<paramsType>) => {
-  const hashes = window.location.hash.split('/');
-  const [ zoneId, setZoneId ] = useState(Number(hashes[2]));
+const ZoneDetailPage = ({
+  startLng,
+  startLat,
+  match,
+}: ZoneDetailPageProps & RouteComponentProps<paramsType>) => {
+  const hashes = window.location.hash.split("/");
+  const [zoneId, setZoneId] = useState(Number(hashes[2]));
+  const feature = hashes[3];
 
   let container = <div></div>;
   const tabItems = sections.map((section) => {
     return (
       <div key={section.name}>
-        <TabItem to={`${zoneId}/${section.to}`} testId={section.to}>
+        <TabItem
+          to={`${zoneId}/${section.to}`}
+          testId={section.to}
+          active={feature === section.to}
+        >
           {section.name}
         </TabItem>
       </div>
@@ -56,11 +65,7 @@ const ZoneDetailPage = ({ startLng, startLat, match }: ZoneDetailPageProps & Rou
 
   switch (match.params.feature) {
     case "timecompare":
-      container = (
-        <TimeCompareContainer
-          currentZoneId={zoneId}
-        />
-      );
+      container = <TimeCompareContainer currentZoneId={zoneId} />;
       break;
     case "transportation":
       container = (

--- a/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
+++ b/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
@@ -59,7 +59,6 @@ const ZoneDetailPage = ({ startLng, startLat, match }: ZoneDetailPageProps & Rou
       container = (
         <TimeCompareContainer
           currentZoneId={zoneId}
-          startAddress="서울시 마포구 431 화인빌라"
         />
       );
       break;

--- a/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
+++ b/src/pages/ZoneDetailPage/ZoneDetailPage.tsx
@@ -1,17 +1,17 @@
-import React, { useState } from "react";
-import "./ZoneDetailPage.scss";
-import { withRouter, RouteComponentProps } from "react-router-dom";
-import queryString from "query-string";
-import styled from "styled-components";
+import React, { useState } from 'react';
+import './ZoneDetailPage.scss';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import queryString from 'query-string';
+import styled from 'styled-components';
 
 //Containers
-import RealEstateContainer from "../../containers/RealEstateContainer/RealEstateContainer";
-import TimeCompareContainer from "../../containers/TimeCompareContainer/TimeCompareContainer";
-import TransportationContainer from "../../containers/TransportationContainer/TransportationContainer";
-import PlaceContainer from "../../containers/PlaceContainer/PlaceContainer";
+import RealEstateContainer from '../../containers/RealEstateContainer/RealEstateContainer';
+import TimeCompareContainer from '../../containers/TimeCompareContainer/TimeCompareContainer';
+import TransportationContainer from '../../containers/TransportationContainer/TransportationContainer';
+import PlaceContainer from '../../containers/PlaceContainer/PlaceContainer';
 
-import ZoneDetailHeaderInfo from "../../components/ZoneInfo/CurrentItemInfo";
-import TabItem from "../../components/TabItem/TabItem";
+import ZoneDetailHeaderInfo from '../../components/ZoneInfo/CurrentItemInfo';
+import TabItem from '../../components/TabItem/TabItem';
 
 type ZoneDetailPageProps = {
   startLng: number;
@@ -23,13 +23,13 @@ type paramsType = {
   feature: string;
 };
 
-const address = "강남구 역삼1동, 서울특별시";
+const address = '강남구 역삼1동, 서울특별시';
 const zoneCode = 301421;
 const sections = [
-  { name: "시간비교", to: "timecompare" },
-  { name: "주거환경", to: "place" },
-  { name: "교통편", to: "transportation" },
-  { name: "매물", to: "realestate" },
+  { name: '시간비교', to: 'timecompare' },
+  { name: '주거환경', to: 'place' },
+  { name: '교통편', to: 'transportation' },
+  { name: '매물', to: 'realestate' },
 ];
 
 const StickyTabs = styled.div`
@@ -44,7 +44,7 @@ const ZoneDetailPage = ({
   startLat,
   match,
 }: ZoneDetailPageProps & RouteComponentProps<paramsType>) => {
-  const hashes = window.location.hash.split("/");
+  const hashes = window.location.hash.split('/');
   const [zoneId, setZoneId] = useState(Number(hashes[2]));
   const feature = hashes[3];
 
@@ -64,10 +64,10 @@ const ZoneDetailPage = ({
   });
 
   switch (match.params.feature) {
-    case "timecompare":
+    case 'timecompare':
       container = <TimeCompareContainer currentZoneId={zoneId} />;
       break;
-    case "transportation":
+    case 'transportation':
       container = (
         <TransportationContainer
           zoneAddress="강남구 역삼1동, 서울특별시"
@@ -77,10 +77,10 @@ const ZoneDetailPage = ({
         />
       );
       break;
-    case "realestate":
+    case 'realestate':
       container = <RealEstateContainer zoneId={zoneId} />;
       break;
-    case "place":
+    case 'place':
       container = <PlaceContainer zoneId={zoneId} />;
       break;
   }

--- a/src/pages/ZoneSearchResultPage/ZoneSearchResultPage.tsx
+++ b/src/pages/ZoneSearchResultPage/ZoneSearchResultPage.tsx
@@ -1,25 +1,25 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   HashRouter,
   Route,
   Switch,
   useLocation,
   useHistory,
-} from "react-router-dom";
+} from 'react-router-dom';
 
-import queryString from "query-string";
+import queryString from 'query-string';
 
 // Page
-import ZoneDetailPage from "../ZoneDetailPage/ZoneDetailPage";
-import ZoneSearchResultContainer from "../../containers/ZoneSearchResultContainer/ZoneSearchResultContainer";
+import ZoneDetailPage from '../ZoneDetailPage/ZoneDetailPage';
+import ZoneSearchResultContainer from '../../containers/ZoneSearchResultContainer/ZoneSearchResultContainer';
 
 // Test
-import { getTestZones } from "../../api/zoneAPI";
-import LoadingContainer from "../../containers/LoadingContainer/LoadingContainer";
-import ModalHooks from "../../hooks/ModalHooks";
+import { getTestZones } from '../../api/zoneAPI';
+import LoadingContainer from '../../containers/LoadingContainer/LoadingContainer';
+import ModalHooks from '../../hooks/ModalHooks';
 
 // Hooks
-import useTimeCompare from "../../hooks/timeCompareHooks";
+import useTimeCompare from '../../hooks/timeCompareHooks';
 
 interface loadingContainer {
   data: locationData;
@@ -47,31 +47,31 @@ const createLoadingContainer = (props: loadingContainer) => {
 };
 
 const convertSearchInfoData = (params: any) => {
-  const type = "회사";
-  let transitMode = "";
-  let transferLimit = "환승 여부 상관없음";
+  const type = '회사';
+  let transitMode = '';
+  let transferLimit = '환승 여부 상관없음';
 
   switch (params.transitMode) {
-    case "subway":
-      transitMode = "지하철";
+    case 'subway':
+      transitMode = '지하철';
       break;
-    case "bus":
-      transitMode = "버스";
+    case 'bus':
+      transitMode = '버스';
       break;
     default:
-      transitMode = "지하철&버스";
+      transitMode = '지하철&버스';
       break;
   }
 
   switch (params.transferLimit) {
     case 0:
-      transferLimit = "환승 없음";
+      transferLimit = '환승 없음';
       break;
     case 1:
-      transferLimit = "1회 환승";
+      transferLimit = '1회 환승';
       break;
     case 2:
-      transferLimit = "2회 환승";
+      transferLimit = '2회 환승';
       break;
     default:
       break;
@@ -100,18 +100,18 @@ const ZoneSearchResultPage = () => {
   const requestZones = useCallback(
     async (data: any) => {
       const headers = {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers":
-          "Origin, X-Requested-With, Content-Type, Accept",
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers':
+          'Origin, X-Requested-With, Content-Type, Accept',
       };
 
       try {
         const res = await getTestZones({ headers, data });
-        
+
         // 이용자가 설정한 주소 저장
-        timeCompare.setLocation("userLocation", {
+        timeCompare.setLocation('userLocation', {
           lat: res.inputLocation.y,
-          lng: res.inputLocation.x
+          lng: res.inputLocation.x,
         });
 
         setZoneData({
@@ -138,9 +138,13 @@ const ZoneSearchResultPage = () => {
   );
 
   useEffect(() => {
-    if (location.hash && !location.hash.match(/zone/) && !zoneData.hasOwnProperty('data')) {
+    if (
+      location.hash &&
+      !location.hash.match(/zone/) &&
+      !zoneData.hasOwnProperty('data')
+    ) {
       const closeCallback = () => {
-        const result = window.confirm("변경사항이 저장되지 않을 수 있습니다.");
+        const result = window.confirm('변경사항이 저장되지 않을 수 있습니다.');
 
         if (result) {
           history.goBack();
@@ -166,7 +170,16 @@ const ZoneSearchResultPage = () => {
             />
           )}
         </Route>
-        <Route exact path="/:id/:feature" component={() => <ZoneDetailPage startLat={timeCompare.userLocation.lat} startLng={timeCompare.userLocation.lng} />} />
+        <Route
+          exact
+          path="/:id/:feature"
+          component={() => (
+            <ZoneDetailPage
+              startLat={timeCompare.userLocation.lat}
+              startLng={timeCompare.userLocation.lng}
+            />
+          )}
+        />
       </Switch>
     </HashRouter>
   );

--- a/src/pages/ZoneSearchResultPage/ZoneSearchResultPage.tsx
+++ b/src/pages/ZoneSearchResultPage/ZoneSearchResultPage.tsx
@@ -110,8 +110,8 @@ const ZoneSearchResultPage = () => {
         
         // 이용자가 설정한 주소 저장
         timeCompare.setLocation("userLocation", {
-          lat: res.inputLocation.x,
-          lng: res.inputLocation.y
+          lat: res.inputLocation.y,
+          lng: res.inputLocation.x
         });
 
         setZoneData({

--- a/src/utils/TimeCompare/functions.ts
+++ b/src/utils/TimeCompare/functions.ts
@@ -23,22 +23,28 @@ export const setTimeCompareItems = (items: TimeCompareItem[]) => {
   localStorage.setItem("timeCompareItems", JSON.stringify(items));
 }
 
-export const timeCompare = async (item: TimeCompareItem, currentZoneId: number, selectedZoneId: number) => {  
+export const timeCompare = async (item: TimeCompareItem, currentZoneId: number, selectedLocation: { lat: number, lng: number }) => {  
   const currentZoneTransitData = await getTransits({
     startLocation: {
+      // 해당 핫플의 lat, lng 구나
       lat: item.location.lat,
       lng: item.location.lng,
     },
+    // currentZoneId는 zoneId 구나
     zoneId: currentZoneId,
     mode: "LocationToZone"
   });
+
   const selectedZoneTransitData = await getTransits({
     startLocation: {
       lat: item.location.lat,
       lng: item.location.lng,
     },
-    zoneId: selectedZoneId,
-    mode: "LocationToZone"
+    destinationLocation: {
+      lat: selectedLocation.lat,
+      lng: selectedLocation.lng
+    },
+    mode: "LocationToLocation"
   });
 
   if (!(currentZoneTransitData && selectedZoneTransitData)) {
@@ -55,7 +61,7 @@ export const timeCompare = async (item: TimeCompareItem, currentZoneId: number, 
   return true;
 }
 
-export const setDefaultTimeCompareItem = async (currentZoneId: number, selectedZoneId: number) => {
+export const setDefaultTimeCompareItem = async (currentZoneId: number, selectedLocation: { lat: number, lng: number }) => {
   const defaultItems = [
     {
       icon: "koex" as const,
@@ -85,7 +91,7 @@ export const setDefaultTimeCompareItem = async (currentZoneId: number, selectedZ
     }
   ];
   for (let item of defaultItems) {
-    await timeCompare(item, currentZoneId, selectedZoneId);
+    await timeCompare(item, currentZoneId, selectedLocation);
   }
   localStorage.setItem("timeCompareItems", JSON.stringify(defaultItems));
   return defaultItems;

--- a/src/utils/TimeCompare/functions.ts
+++ b/src/utils/TimeCompare/functions.ts
@@ -48,7 +48,6 @@ export const timeCompare = async (item: TimeCompareItem, currentZoneId: number, 
   });
 
   if (!(currentZoneTransitData && selectedZoneTransitData)) {
-    alert('주소를 설정해주세요');
     return false;
   }
 


### PR DESCRIPTION
[ Issue#107 ]
Dialog 컴포넌트가 화면 상에 나타날 때 중앙이 아니라 다른 곳에서 나타나게 되는 문제를 고쳤습니다. 이제 Dialog 컴포넌트는 항상 중앙에 위치하게 됩니다.

[ Issue#108 ]
Zone 상세 정보 페이지 헤더가 현재 PC와 모바일 모두 화면 전체 너비로 늘어나서 렌더링 되고 있는문제를 둘다 적절한 크기만큼만 늘어나도록 만들어 해결했습니다.

[ Issue#109 ]
이용자가 자신이 살고 있는 주소를 넣으면 시간 비교 아이템들이 그 주소에 맞춰서 시간 비교가 이루어지도록, 그리고 이용자가 본인이 원하는 시간 비교 아이템을 추가할 수 있도록 만들었습니다.

[ Issue#111 ]
Tabs 를 클릭하면 폰트 색과 아래 테두리 색이 해당 탭에 있는 동안에는 변하도록 했습니다.

* 추가 : 존을 클릭하면 리스트뷰가 토글되도록 만들었습니다.